### PR TITLE
Fix cursor advance after building garage

### DIFF
--- a/Echoes of the Hollow/Assets/AdvancedHouseBuilder.cs
+++ b/Echoes of the Hollow/Assets/AdvancedHouseBuilder.cs
@@ -117,8 +117,8 @@ public class AdvancedHouseBuilder : MonoBehaviour
             false,
             garage);
 
-        // Advance cursor to far interior edge
-        cursor.x += INTERIOR_W + WALL_THICKNESS;
+        // Advance cursor beyond the garage (far exterior edge)
+        cursor.x += exteriorW;
     }
 
     GameObject CreateCube(string name, Vector3 centre, Vector3 size, Material m, Transform parent)


### PR DESCRIPTION
## Summary
- update `BuildGarage` to move the cursor beyond the garage's outer edge
- adjust comment to match logic

## Testing
- `mcs 'Echoes of the Hollow'/Assets/AdvancedHouseBuilder.cs` *(fails: `UnityEngine` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683e25b597808322b3af56c5278a12af