### PR TITLE
Fix window gap in BuildWallWithOpening

### DIFF
--- a/Echoes of the Hollow/Assets/AdvancedHouseBuilder.cs
+++ b/Echoes of the Hollow/Assets/AdvancedHouseBuilder.cs
@@ -244,7 +244,9 @@ public class AdvancedHouseBuilder : MonoBehaviour
 
         if (isWindow && openHeight > 0f)
         {
-            SpawnSeg(leftLen, 0f, 0f, openWidth, openHeight, thick);
+            // Adjust the y-position of the sill segment to leave a gap
+            // when creating a window opening.
+            SpawnSeg(leftLen, 0.1f, 0f, openWidth, openHeight - 0.1f, thick);
         }
 
         if (aboveHeight > 0f)


### PR DESCRIPTION
## Summary
- avoid closing the window opening by offsetting the sill segment when `isWindow` is true

## Testing
- `npm test` *(fails: package.json missing)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683e2f8616608322ac126e9d59b68eac