### PR TITLE
Fix living room z0 initialization

### DIFF
--- a/Echoes of the Hollow/Assets/AdvancedHouseBuilder.cs
+++ b/Echoes of the Hollow/Assets/AdvancedHouseBuilder.cs
@@ -132,7 +132,7 @@ public class AdvancedHouseBuilder : MonoBehaviour
         const float D = 15f * FT;
 
         float x0 = cursor.x;
-        float z0 = 0f;
+        float z0 = cursor.z;
 
         float exteriorW = W + WALL_THICKNESS;
         float exteriorD = D + WALL_THICKNESS * 2f;


### PR DESCRIPTION
## Summary
- use `cursor.z` when initializing `z0` in `BuildLivingRoom`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683e3fcd92f08322a34fe69fc55d6821