### PR TITLE
Add explanation for living room width

### DIFF
--- a/Echoes of the Hollow/Assets/AdvancedHouseBuilder.cs
+++ b/Echoes of the Hollow/Assets/AdvancedHouseBuilder.cs
@@ -134,6 +134,8 @@ public class AdvancedHouseBuilder : MonoBehaviour
         float x0 = cursor.x;
         float z0 = 0f;
 
+        // Assuming the 'left' wall is shared or connects to an adjacent room's opening (e.g., Foyer's right wall),
+        // so the exterior width calculation only accounts for the new 'right' exterior wall.
         float exteriorW = W + WALL_THICKNESS;
         float exteriorD = D + WALL_THICKNESS * 2f;
 


### PR DESCRIPTION
## Summary
- document why the living room exterior width only uses one wall thickness

## Testing
- `echo "No tests present"`

------
https://chatgpt.com/codex/tasks/task_e_683e3fdac7488322acb2abe835853b99