### PR TITLE
Fix method names and logs

### DIFF
--- a/Echoes of the Hollow/Assets/Player/InputManager.cs
+++ b/Echoes of the Hollow/Assets/Player/InputManager.cs
@@ -18,15 +18,15 @@ public class InputManager : MonoBehaviour
 
         groundMovement.HorizontalMovement.performed += ctx => horizontalInput = ctx.ReadValue<Vector2>();
 
-        groundMovement.Jump.performed += _ => movement.onJumpPressed();
+        groundMovement.Jump.performed += _ => movement.OnJumpPressed();
 
         groundMovement.MouseX.performed += ctx => mouseInput.x = ctx.ReadValue<float>();
         groundMovement.MouseY.performed += ctx => mouseInput.y = ctx.ReadValue<float>();
     }
 
     private void Update (){
-        movement.RecieveInput(horizontalInput);
-        mouseLook.RecieveInput(mouseInput);
+        movement.ReceiveInput(horizontalInput);
+        mouseLook.ReceiveInput(mouseInput);
     }
 
     private void OnEnable (){

--- a/Echoes of the Hollow/Assets/Player/MouseLook.cs
+++ b/Echoes of the Hollow/Assets/Player/MouseLook.cs
@@ -21,7 +21,7 @@ public class MouseLook : MonoBehaviour
         playerCamera.eulerAngles = targetRotation;
     }
 
-    public void RecieveInput (Vector2 mouseInput){
+    public void ReceiveInput (Vector2 mouseInput){
         mouseX = mouseInput.x * sensitivityX;
         mouseY = mouseInput.y * sensitivityY;
     }

--- a/Echoes of the Hollow/Assets/Player/Movement.cs
+++ b/Echoes of the Hollow/Assets/Player/Movement.cs
@@ -34,12 +34,12 @@ public class Movement : MonoBehaviour
         controller.Move(verticalVelocity * Time.deltaTime);
     }
 
-    public void RecieveInput (Vector2 _horizontalInput){
+    public void ReceiveInput (Vector2 _horizontalInput){
         horizontalInput = _horizontalInput;
-        print(horizontalInput);
+        Debug.Log(horizontalInput);
     }
 
-    public void onJumpPressed (){
+    public void OnJumpPressed (){
         jump = true;
     }
 }


### PR DESCRIPTION
## Summary
- rename `RecieveInput` to `ReceiveInput` in Movement and MouseLook
- rename `onJumpPressed` to `OnJumpPressed`
- update references in InputManager
- use `Debug.Log` for horizontal input logging

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_683e563959188322b579ed565f479add