### PR TITLE
Add WallSegment definition

### DIFF
--- a/Echoes of the Hollow/Assets/HousePlan/HousePlanSO.cs
+++ b/Echoes of the Hollow/Assets/HousePlan/HousePlanSO.cs
@@ -21,6 +21,59 @@ public struct RoomData
 }
 
 [System.Serializable]
+public enum WallSide
+{
+    North,
+    South,
+    East,
+    West
+}
+
+[System.Serializable]
+public struct WallSegment
+{
+    /// <summary>
+    /// Starting position of the wall relative to the room or global origin.
+    /// </summary>
+    public Vector3 startPoint;
+
+    /// <summary>
+    /// Ending position of the wall relative to the room or global origin.
+    /// </summary>
+    public Vector3 endPoint;
+
+    /// <summary>
+    /// Thickness of the wall in meters.
+    /// </summary>
+    public float thickness;
+
+    /// <summary>
+    /// Cardinal side of the room the wall sits on.
+    /// </summary>
+    public WallSide side;
+
+    /// <summary>
+    /// Whether this wall is part of the building exterior.
+    /// </summary>
+    public bool isExterior;
+
+    /// <summary>
+    /// IDs of doors contained within this wall.
+    /// </summary>
+    public List<string> doorIdsOnWall;
+
+    /// <summary>
+    /// IDs of windows contained within this wall.
+    /// </summary>
+    public List<string> windowIdsOnWall;
+
+    /// <summary>
+    /// IDs of openings such as passthroughs within this wall.
+    /// </summary>
+    public List<string> openingIdsOnWall;
+}
+
+[System.Serializable]
 public struct DoorSpec
 {
     // Placeholder for door specifications


### PR DESCRIPTION
## Summary
- create `WallSide` enum
- create `WallSegment` struct for wall metadata in house plans

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_683f5630232883228fc99d737e49de87