### PR TITLE
Add JSON export for HousePlan

### DIFF
--- a/Echoes of the Hollow/Assets/Editor/BlueprintPlanExporter.cs
+++ b/Echoes of the Hollow/Assets/Editor/BlueprintPlanExporter.cs
@@ -1,0 +1,42 @@
+using System.IO;
+using UnityEditor;
+using UnityEngine;
+
+/// <summary>
+/// Menu utilities for exporting <see cref="HousePlanSO"/> assets to JSON.
+/// </summary>
+public static class BlueprintPlanExporter
+{
+    [MenuItem("House Tools/Export HousePlan to JSON")]
+    private static void ExportSelectedPlan()
+    {
+        var plan = Selection.activeObject as HousePlanSO;
+        if (plan == null)
+        {
+            Debug.LogError("Please select a HousePlanSO asset to export.");
+            return;
+        }
+
+        string directory = Path.Combine("Assets", "StreamingAssets");
+        if (!AssetDatabase.IsValidFolder(directory))
+        {
+            Directory.CreateDirectory(directory);
+            AssetDatabase.Refresh();
+        }
+
+        string path = EditorUtility.SaveFilePanelInProject(
+            "Export HousePlan to JSON",
+            plan.name + ".json",
+            "json",
+            "Choose a location within StreamingAssets",
+            directory);
+
+        if (string.IsNullOrEmpty(path))
+        {
+            return;
+        }
+
+        BlueprintJsonWriter.Write(plan, path);
+        Debug.Log($"HousePlan exported to {path}");
+    }
+}

--- a/Echoes of the Hollow/Assets/HousePlan/BlueprintJsonWriter.cs
+++ b/Echoes of the Hollow/Assets/HousePlan/BlueprintJsonWriter.cs
@@ -1,0 +1,34 @@
+using System.IO;
+using UnityEngine;
+
+/// <summary>
+/// Utility for writing <see cref="HousePlanSO"/> data to a JSON file.
+/// </summary>
+public static class BlueprintJsonWriter
+{
+    /// <summary>
+    /// Serialises the given <see cref="HousePlanSO"/> to the specified JSON path.
+    /// </summary>
+    /// <param name="plan">House plan to serialise.</param>
+    /// <param name="pathJson">Path to the output JSON file.</param>
+    public static void Write(HousePlanSO plan, string pathJson)
+    {
+        if (plan == null || string.IsNullOrEmpty(pathJson))
+        {
+            Debug.LogError("Invalid arguments supplied to BlueprintJsonWriter.Write.");
+            return;
+        }
+
+        string json = JsonUtility.ToJson(plan, true);
+        string directory = Path.GetDirectoryName(pathJson);
+        if (!string.IsNullOrEmpty(directory) && !Directory.Exists(directory))
+        {
+            Directory.CreateDirectory(directory);
+        }
+
+        File.WriteAllText(pathJson, json);
+#if UNITY_EDITOR
+        UnityEditor.AssetDatabase.Refresh();
+#endif
+    }
+}


### PR DESCRIPTION
## Summary
- implement `BlueprintJsonWriter.Write` for serializing `HousePlanSO` to JSON
- add `BlueprintPlanExporter` menu item to export selected plan

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683f5cccbd348322a1c514e495b89c8e