### PR TITLE
Add cutout placeholder logging for walls

### DIFF
--- a/Echoes of the Hollow/Assets/HousePlan/Log.cs
+++ b/Echoes of the Hollow/Assets/HousePlan/Log.cs
@@ -1,0 +1,17 @@
+using UnityEngine;
+
+/// <summary>
+/// Simple logging utility wrapping <see cref="Debug"/> to provide
+/// Info level messages.
+/// </summary>
+public static class Log
+{
+    /// <summary>
+    /// Logs an informational message to the Unity console.
+    /// </summary>
+    /// <param name="message">Message to log.</param>
+    public static void Info(string message)
+    {
+        Debug.Log(message);
+    }
+}

--- a/Echoes of the Hollow/Assets/HousePlan/RoomBuilder.cs
+++ b/Echoes of the Hollow/Assets/HousePlan/RoomBuilder.cs
@@ -53,6 +53,7 @@ public static class RoomBuilder
                 {
                     wall.name = $"Wall_{room.roomId}_{wallIndex}";
                     wall.transform.SetParent(root.transform, false);
+                    ProcessWallCutouts(segment, wall.name, housePlan);
                     wallIndex++;
                 }
             }
@@ -188,5 +189,58 @@ public static class RoomBuilder
         string aStr = $"{a.x:F3}_{a.y:F3}_{a.z:F3}";
         string bStr = $"{b.x:F3}_{b.y:F3}_{b.z:F3}";
         return $"{aStr}-{bStr}";
+    }
+
+    private static void ProcessWallCutouts(WallSegment segment, string wallId, HousePlanSO plan)
+    {
+        if (plan == null)
+        {
+            return;
+        }
+
+        if (segment.doorIdsOnWall != null)
+        {
+            foreach (string id in segment.doorIdsOnWall)
+            {
+                foreach (DoorSpec spec in plan.doors)
+                {
+                    if (spec.doorId == id)
+                    {
+                        Log.Info($"Placeholder for cut-out: {spec.doorId} on wall {wallId} at position {spec.position} with size {spec.width}x{spec.height}");
+                        break;
+                    }
+                }
+            }
+        }
+
+        if (segment.windowIdsOnWall != null)
+        {
+            foreach (string id in segment.windowIdsOnWall)
+            {
+                foreach (WindowSpec spec in plan.windows)
+                {
+                    if (spec.windowId == id)
+                    {
+                        Log.Info($"Placeholder for cut-out: {spec.windowId} on wall {wallId} at position {spec.position} with size {spec.width}x{spec.height}");
+                        break;
+                    }
+                }
+            }
+        }
+
+        if (segment.openingIdsOnWall != null)
+        {
+            foreach (string id in segment.openingIdsOnWall)
+            {
+                foreach (OpeningSpec spec in plan.openings)
+                {
+                    if (spec.openingId == id)
+                    {
+                        Log.Info($"Placeholder for cut-out: {spec.openingId} on wall {wallId} at position {spec.position} with size {spec.width}x{spec.height}");
+                        break;
+                    }
+                }
+            }
+        }
     }
 }

--- a/Echoes of the Hollow/Assets/HousePlan/WallBuilder.cs
+++ b/Echoes of the Hollow/Assets/HousePlan/WallBuilder.cs
@@ -43,6 +43,7 @@ public static class WallBuilder
                 {
                     wallObj.name = $"Wall_{room.roomId}_{wallIndex}";
                     wallObj.transform.SetParent(root.transform, false);
+                    ProcessWallCutouts(segment, wallObj.name, housePlan);
                 }
                 wallIndex++;
             }
@@ -121,6 +122,59 @@ public static class WallBuilder
         wall.transform.position = startWorld;
         wall.transform.rotation = Quaternion.FromToRotation(Vector3.right, direction);
         return wall;
+    }
+
+    private static void ProcessWallCutouts(WallSegment segment, string wallId, HousePlanSO plan)
+    {
+        if (plan == null)
+        {
+            return;
+        }
+
+        if (segment.doorIdsOnWall != null)
+        {
+            foreach (string id in segment.doorIdsOnWall)
+            {
+                foreach (DoorSpec spec in plan.doors)
+                {
+                    if (spec.doorId == id)
+                    {
+                        Log.Info($"Placeholder for cut-out: {spec.doorId} on wall {wallId} at position {spec.position} with size {spec.width}x{spec.height}");
+                        break;
+                    }
+                }
+            }
+        }
+
+        if (segment.windowIdsOnWall != null)
+        {
+            foreach (string id in segment.windowIdsOnWall)
+            {
+                foreach (WindowSpec spec in plan.windows)
+                {
+                    if (spec.windowId == id)
+                    {
+                        Log.Info($"Placeholder for cut-out: {spec.windowId} on wall {wallId} at position {spec.position} with size {spec.width}x{spec.height}");
+                        break;
+                    }
+                }
+            }
+        }
+
+        if (segment.openingIdsOnWall != null)
+        {
+            foreach (string id in segment.openingIdsOnWall)
+            {
+                foreach (OpeningSpec spec in plan.openings)
+                {
+                    if (spec.openingId == id)
+                    {
+                        Log.Info($"Placeholder for cut-out: {spec.openingId} on wall {wallId} at position {spec.position} with size {spec.width}x{spec.height}");
+                        break;
+                    }
+                }
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- add Log utility
- log placeholder messages for doors, windows and openings when generating walls
- hook logging into exterior and interior wall builders

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683f992fa2248322aed7f9eface2a791