### PR TITLE
Add window placement utility and prefabs

### DIFF
--- a/Echoes of the Hollow/Assets/HousePlan/WindowPlaceholder.cs
+++ b/Echoes of the Hollow/Assets/HousePlan/WindowPlaceholder.cs
@@ -1,0 +1,92 @@
+using UnityEngine;
+
+/// <summary>
+/// Runtime helper that procedurally creates very simple geometry for window
+/// placeholder prefabs.
+/// </summary>
+public class WindowPlaceholder : MonoBehaviour
+{
+    public enum PlaceholderType
+    {
+        SingleHung,
+        Sliding,
+        Bay,
+        SkylightQuad
+    }
+
+    [SerializeField] private PlaceholderType placeholderType;
+
+    private void Awake()
+    {
+        BuildPlaceholder();
+    }
+
+#if UNITY_EDITOR
+    private void OnValidate()
+    {
+        if (!Application.isPlaying)
+        {
+            for (int i = transform.childCount - 1; i >= 0; i--)
+            {
+                DestroyImmediate(transform.GetChild(i).gameObject);
+            }
+            BuildPlaceholder();
+        }
+    }
+#endif
+
+    private void BuildPlaceholder()
+    {
+        switch (placeholderType)
+        {
+            case PlaceholderType.SingleHung:
+            case PlaceholderType.Sliding:
+                BuildSimpleFrame();
+                break;
+            case PlaceholderType.Bay:
+                BuildBayFrame();
+                break;
+            case PlaceholderType.SkylightQuad:
+                BuildSkylight();
+                break;
+        }
+    }
+
+    private void BuildSimpleFrame()
+    {
+        GameObject frame = GameObject.CreatePrimitive(PrimitiveType.Cube);
+        frame.name = "Frame";
+        frame.transform.SetParent(transform, false);
+        frame.transform.localScale = new Vector3(1f, 1f, 0.05f);
+
+        GameObject glass = GameObject.CreatePrimitive(PrimitiveType.Cube);
+        glass.name = "Glass";
+        glass.transform.SetParent(transform, false);
+        glass.transform.localScale = new Vector3(0.9f, 0.9f, 0.02f);
+        glass.transform.localPosition = Vector3.zero;
+    }
+
+    private void BuildBayFrame()
+    {
+        const float angle = 30f;
+        for (int i = 0; i < 3; i++)
+        {
+            GameObject segment = new GameObject($"Segment_{i}");
+            segment.transform.SetParent(transform, false);
+            segment.transform.localRotation = Quaternion.Euler(0f, (i - 1) * angle, 0f);
+
+            GameObject cube = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            cube.transform.SetParent(segment.transform, false);
+            cube.transform.localScale = new Vector3(0.6f, 1f, 0.05f);
+        }
+    }
+
+    private void BuildSkylight()
+    {
+        GameObject quad = GameObject.CreatePrimitive(PrimitiveType.Quad);
+        quad.name = "Skylight";
+        quad.transform.SetParent(transform, false);
+        quad.transform.localRotation = Quaternion.Euler(90f, 0f, 0f);
+        quad.transform.localScale = new Vector3(1f, 1f, 1f);
+    }
+}

--- a/Echoes of the Hollow/Assets/HousePlan/WindowPlaceholder.cs.meta
+++ b/Echoes of the Hollow/Assets/HousePlan/WindowPlaceholder.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: e2645b95369bb6940bb3c3c4c9981cfa

--- a/Echoes of the Hollow/Assets/HousePlan/WindowPlacer.cs
+++ b/Echoes of the Hollow/Assets/HousePlan/WindowPlacer.cs
@@ -1,0 +1,76 @@
+using UnityEngine;
+
+/// <summary>
+/// Utility for instantiating placeholder window prefabs based on a
+/// <see cref="HousePlanSO"/> definition.
+/// </summary>
+public static class WindowPlacer
+{
+    /// <summary>
+    /// Instantiates placeholder window prefabs for all <see cref="WindowSpec"/>
+    /// entries in the supplied plan.
+    /// </summary>
+    /// <param name="housePlan">Plan containing window specs.</param>
+    /// <param name="wallsContainer">Parent transform containing generated wall segments.</param>
+    public static void PlaceAllWindows(HousePlanSO housePlan, GameObject wallsContainer)
+    {
+        if (housePlan == null || wallsContainer == null)
+        {
+            Debug.LogError("Invalid arguments supplied to WindowPlacer.PlaceAllWindows");
+            return;
+        }
+
+        foreach (WindowSpec spec in housePlan.windows)
+        {
+            GameObject prefab = LoadWindowPrefab(spec.type);
+            if (prefab == null)
+            {
+                Debug.LogWarning($"No prefab found for window type {spec.type}");
+                continue;
+            }
+
+            Transform wall = FindWallTransform(spec.wallId, wallsContainer.transform);
+            if (wall == null)
+            {
+                Debug.LogWarning($"Wall {spec.wallId} not found for window {spec.windowId}");
+                continue;
+            }
+
+            GameObject instance = Object.Instantiate(prefab, wall);
+            instance.name = $"Window_{spec.windowId}";
+            instance.transform.localPosition = new Vector3(spec.position.x, spec.sillHeight, spec.position.z);
+            instance.transform.localRotation = Quaternion.identity;
+        }
+    }
+
+    private static GameObject LoadWindowPrefab(WindowType type)
+    {
+        string prefabName = type switch
+        {
+            WindowType.SingleHung => "Window_SingleHung_Placeholder",
+            WindowType.Sliding => "Window_Sliding_Placeholder",
+            WindowType.Bay => "Window_Bay_Placeholder",
+            WindowType.SkylightQuad => "Skylight_Quad_Placeholder",
+            _ => null
+        };
+
+        if (string.IsNullOrEmpty(prefabName))
+        {
+            return null;
+        }
+
+        return Resources.Load<GameObject>(prefabName);
+    }
+
+    private static Transform FindWallTransform(string wallId, Transform container)
+    {
+        foreach (Transform child in container)
+        {
+            if (child.gameObject.name == wallId)
+            {
+                return child;
+            }
+        }
+        return null;
+    }
+}

--- a/Echoes of the Hollow/Assets/HousePlan/WindowPlacer.cs.meta
+++ b/Echoes of the Hollow/Assets/HousePlan/WindowPlacer.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 204e262304a7018517550cea67a2d71f

--- a/Echoes of the Hollow/Assets/Resources/Skylight_Quad_Placeholder.prefab
+++ b/Echoes of the Hollow/Assets/Resources/Skylight_Quad_Placeholder.prefab
@@ -1,0 +1,46 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4}
+  - component: {fileID: 11400000}
+  m_Layer: 0
+  m_Name: Skylight_Quad_Placeholder
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e2645b95369bb6940bb3c3c4c9981cfa, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  placeholderType: 3

--- a/Echoes of the Hollow/Assets/Resources/Skylight_Quad_Placeholder.prefab.meta
+++ b/Echoes of the Hollow/Assets/Resources/Skylight_Quad_Placeholder.prefab.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: d5f7d44b4a5b2d43a0252fe88eced5bf

--- a/Echoes of the Hollow/Assets/Resources/Window_Bay_Placeholder.prefab
+++ b/Echoes of the Hollow/Assets/Resources/Window_Bay_Placeholder.prefab
@@ -1,0 +1,46 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4}
+  - component: {fileID: 11400000}
+  m_Layer: 0
+  m_Name: Window_Bay_Placeholder
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e2645b95369bb6940bb3c3c4c9981cfa, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  placeholderType: 2

--- a/Echoes of the Hollow/Assets/Resources/Window_Bay_Placeholder.prefab.meta
+++ b/Echoes of the Hollow/Assets/Resources/Window_Bay_Placeholder.prefab.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 8f8ee0dc8f623c776d82fe492f8afc9d

--- a/Echoes of the Hollow/Assets/Resources/Window_SingleHung_Placeholder.prefab
+++ b/Echoes of the Hollow/Assets/Resources/Window_SingleHung_Placeholder.prefab
@@ -1,0 +1,46 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4}
+  - component: {fileID: 11400000}
+  m_Layer: 0
+  m_Name: Window_SingleHung_Placeholder
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e2645b95369bb6940bb3c3c4c9981cfa, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  placeholderType: 0

--- a/Echoes of the Hollow/Assets/Resources/Window_SingleHung_Placeholder.prefab.meta
+++ b/Echoes of the Hollow/Assets/Resources/Window_SingleHung_Placeholder.prefab.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: b5f9df379d3a0f5d686bd9ac87887530

--- a/Echoes of the Hollow/Assets/Resources/Window_Sliding_Placeholder.prefab
+++ b/Echoes of the Hollow/Assets/Resources/Window_Sliding_Placeholder.prefab
@@ -1,0 +1,46 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4}
+  - component: {fileID: 11400000}
+  m_Layer: 0
+  m_Name: Window_Sliding_Placeholder
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e2645b95369bb6940bb3c3c4c9981cfa, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  placeholderType: 1

--- a/Echoes of the Hollow/Assets/Resources/Window_Sliding_Placeholder.prefab.meta
+++ b/Echoes of the Hollow/Assets/Resources/Window_Sliding_Placeholder.prefab.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: b9d4a18774f085ec67c79c206e6e660f


### PR DESCRIPTION
## Summary
- implement `WindowPlacer` for placing windows from `HousePlanSO`
- add `WindowPlaceholder` component that procedurally builds simple window geometry
- provide placeholder prefabs for single hung, sliding, bay and skylight windows

## Testing
- `dotnet test` *(fails: no project file)*

------
https://chatgpt.com/codex/tasks/task_e_683fa257abc083229ea12e8874ebc7fb