### PR TITLE
I've refactored the wall generation to use a slice-based approach wit…

### DIFF
--- a/Echoes of the Hollow/Assets/HousePlan/RoomBuilder.cs
+++ b/Echoes of the Hollow/Assets/HousePlan/RoomBuilder.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq; // Added for Distinct() and OrderBy()
 using UnityEngine;
 
 /// <summary>
@@ -40,20 +41,19 @@ public static class RoomBuilder
                     continue;
                 }
 
-                Vector3 startWorld = room.position + segment.startPoint;
-                Vector3 endWorld = room.position + segment.endPoint;
-                string key = GetSegmentKey(startWorld, endWorld);
+                // startWorld and endWorld are now calculated inside BuildWallSegment
+                string key = GetSegmentKey(room.position + segment.startPoint, room.position + segment.endPoint);
                 if (!builtKeys.Add(key))
                 {
                     continue; // Avoid duplicate walls shared between rooms
                 }
 
-                GameObject wall = BuildWallSegment(startWorld, endWorld, storyHeight, housePlan.interiorWallThickness);
+                GameObject wall = BuildWallSegment(segment, room.position, storyHeight, housePlan.interiorWallThickness, housePlan);
                 if (wall != null)
                 {
                     wall.name = $"Wall_{room.roomId}_{wallIndex}";
                     wall.transform.SetParent(root.transform, false);
-                    ProcessWallCutouts(segment, wall.name, housePlan);
+                    // ProcessWallCutouts(segment, wall.name, housePlan); // Removed call
                     wallIndex++;
                 }
             }
@@ -72,43 +72,42 @@ public static class RoomBuilder
 
         if (stairwell.HasValue && stairwell.Value.dimensions.x > 0f && stairwell.Value.dimensions.y > 0f)
         {
-            BuildRectangularEnclosure(stairwell.Value, root.transform, storyHeight, housePlan.interiorWallThickness, builtKeys, ref wallIndex);
+            BuildRectangularEnclosure(stairwell.Value, root.transform, storyHeight, housePlan.interiorWallThickness, builtKeys, ref wallIndex, housePlan); // Added housePlan
         }
 
         return root;
     }
 
     // ---------------------------------------------------------------------
-    private static GameObject BuildWallSegment(Vector3 startWorld, Vector3 endWorld, float height, float thickness)
+    private static Mesh GenerateWallSliceMesh(float sliceLength, float sliceHeight, float thickness, Vector3 sliceOffset)
     {
-        Vector3 direction = endWorld - startWorld;
-        float length = direction.magnitude;
-        if (length <= 0.001f)
-        {
-            return null;
-        }
-
         float halfThickness = thickness * 0.5f;
 
         Vector3[] vertices = new Vector3[8]
         {
-            new Vector3(0f, 0f, -halfThickness),
-            new Vector3(length, 0f, -halfThickness),
-            new Vector3(0f, height, -halfThickness),
-            new Vector3(length, height, -halfThickness),
-            new Vector3(0f, 0f, halfThickness),
-            new Vector3(length, 0f, halfThickness),
-            new Vector3(0f, height, halfThickness),
-            new Vector3(length, height, halfThickness)
+            sliceOffset + new Vector3(0f, 0f, -halfThickness),
+            sliceOffset + new Vector3(sliceLength, 0f, -halfThickness),
+            sliceOffset + new Vector3(0f, sliceHeight, -halfThickness),
+            sliceOffset + new Vector3(sliceLength, sliceHeight, -halfThickness),
+            sliceOffset + new Vector3(0f, 0f, halfThickness),
+            sliceOffset + new Vector3(sliceLength, 0f, halfThickness),
+            sliceOffset + new Vector3(0f, sliceHeight, halfThickness),
+            sliceOffset + new Vector3(sliceLength, sliceHeight, halfThickness)
         };
 
         int[] triangles = new int[36]
         {
+            // Front
             0, 2, 1, 1, 2, 3,
+            // Back
             4, 5, 6, 5, 7, 6,
+            // Bottom
             0, 1, 4, 1, 5, 4,
+            // Top
             2, 6, 3, 3, 6, 7,
+            // Right
             1, 3, 5, 3, 7, 5,
+            // Left
             0, 4, 2, 2, 4, 6
         };
 
@@ -131,15 +130,188 @@ public static class RoomBuilder
             uv = uvs
         };
         mesh.RecalculateNormals();
+        return mesh;
+    }
 
-        GameObject wall = new GameObject("InteriorWall");
-        MeshFilter filter = wall.AddComponent<MeshFilter>();
-        filter.mesh = mesh;
-        wall.AddComponent<MeshRenderer>();
+    // ---------------------------------------------------------------------
+    private static GameObject BuildWallSegment(WallSegment segment, Vector3 roomPosition, float storyHeight, float thickness, HousePlanSO housePlan)
+    {
+        // Corrected: Calculate wallStartWorld, wallEndWorld, and segmentLength first
+        Vector3 wallStartWorld = roomPosition + segment.startPoint;
+        Vector3 wallEndWorld = roomPosition + segment.endPoint;
+        float segmentLength = (wallEndWorld - wallStartWorld).magnitude;
 
-        wall.transform.position = startWorld;
-        wall.transform.rotation = Quaternion.FromToRotation(Vector3.right, direction);
-        return wall;
+        if (segmentLength <= 0.01f) // Negligible length
+        {
+            return null;
+        }
+
+        // Define directions for rotation (original) and dot products (normalized)
+        Vector3 originalDirection = wallEndWorld - wallStartWorld;
+        Vector3 wallDirection = originalDirection.normalized; // Used for dot products
+
+        GameObject wallRoot = new GameObject("WallSegment"); // Standardized name
+        wallRoot.transform.position = wallStartWorld; // Use new variable
+        wallRoot.transform.rotation = Quaternion.FromToRotation(Vector3.right, originalDirection); // Use non-normalized for rotation
+
+        List<float> cutMarkers = new List<float> { 0f, segmentLength }; // Initialize before adding opening markers
+
+        // Gather Openings
+        List<DoorSpec> relevantDoors = new List<DoorSpec>();
+        List<WindowSpec> relevantWindows = new List<WindowSpec>(); // Interior windows might be rare but supported
+        List<OpeningSpec> relevantOpenings = new List<OpeningSpec>();
+
+        if (housePlan != null) // Ensure housePlan is not null
+        {
+            if (segment.doorIdsOnWall != null && housePlan.doors != null)
+            {
+                foreach (string doorId in segment.doorIdsOnWall)
+                {
+                    DoorSpec door = housePlan.doors.Find(d => d.doorId == doorId);
+                    if (door != null) relevantDoors.Add(door);
+                }
+            }
+
+            if (segment.windowIdsOnWall != null && housePlan.windows != null)
+            {
+                foreach (string windowId in segment.windowIdsOnWall)
+                {
+                    WindowSpec window = housePlan.windows.Find(w => w.windowId == windowId);
+                    if (window != null) relevantWindows.Add(window);
+                }
+            }
+
+            if (segment.openingIdsOnWall != null && housePlan.openings != null)
+            {
+                foreach (string openingId in segment.openingIdsOnWall)
+                {
+                    OpeningSpec opening = housePlan.openings.Find(o => o.openingId == openingId);
+                    if (opening != null) relevantOpenings.Add(opening);
+                }
+            }
+        }
+
+        // Add Cut Markers from Openings using corrected logic (wallDirection is already defined)
+        foreach (DoorSpec door in relevantDoors)
+        {
+            Vector3 doorWorldPosition = roomPosition + door.position; // Assuming door.position is relative to roomPosition
+            Vector3 vectorFromWallStartToDoor = doorWorldPosition - wallStartWorld;
+            float distanceAlongWall = Vector3.Dot(vectorFromWallStartToDoor, wallDirection);
+            cutMarkers.Add(Mathf.Clamp(distanceAlongWall, 0f, segmentLength));
+            cutMarkers.Add(Mathf.Clamp(distanceAlongWall + door.width, 0f, segmentLength));
+        }
+        foreach (WindowSpec window in relevantWindows)
+        {
+            Vector3 windowWorldPosition = roomPosition + window.position; // Assuming window.position is relative to roomPosition
+            Vector3 vectorFromWallStartToWindow = windowWorldPosition - wallStartWorld;
+            float distanceAlongWall = Vector3.Dot(vectorFromWallStartToWindow, wallDirection);
+            cutMarkers.Add(Mathf.Clamp(distanceAlongWall, 0f, segmentLength));
+            cutMarkers.Add(Mathf.Clamp(distanceAlongWall + window.width, 0f, segmentLength));
+        }
+        foreach (OpeningSpec opening in relevantOpenings)
+        {
+            Vector3 openingWorldPosition = opening.position; // opening.position is relative to house origin
+            Vector3 vectorFromWallStartToOpening = openingWorldPosition - wallStartWorld;
+            float distanceAlongWall = Vector3.Dot(vectorFromWallStartToOpening, wallDirection);
+            cutMarkers.Add(Mathf.Clamp(distanceAlongWall, 0f, segmentLength));
+            cutMarkers.Add(Mathf.Clamp(distanceAlongWall + opening.width, 0f, segmentLength));
+        }
+
+        // Sort and remove duplicate markers
+        cutMarkers = cutMarkers.Distinct().OrderBy(m => m).ToList();
+
+        // Iterate Through Marker Pairs and build slices
+        for (int i = 0; i < cutMarkers.Count - 1; i++)
+        {
+            float markerA = cutMarkers[i];
+            float markerB = cutMarkers[i + 1];
+            float sliceStart = markerA;
+            float sliceLength = markerB - markerA;
+
+            if (sliceLength <= 0.01f) // Negligible length, skip
+            {
+                continue;
+            }
+
+            float sliceMidPoint = sliceStart + sliceLength / 2f;
+            bool openingFound = false;
+
+            // Check for Windows
+            foreach (WindowSpec window in relevantWindows)
+            {
+                if (sliceMidPoint >= window.position.x && sliceMidPoint < (window.position.x + window.width))
+                {
+                    // Sill Slice (below window)
+                    if (window.sillHeight > 0.01f)
+                    {
+                        Mesh sillMesh = GenerateWallSliceMesh(sliceLength, window.sillHeight, thickness, Vector3.zero);
+                        GameObject sillGo = new GameObject("Sill");
+                        sillGo.AddComponent<MeshFilter>().mesh = sillMesh;
+                        sillGo.AddComponent<MeshRenderer>(); // TODO: Assign material
+                        sillGo.transform.SetParent(wallRoot.transform, false);
+                        sillGo.transform.localPosition = new Vector3(sliceStart, 0, 0);
+                    }
+
+                    // Lintel Slice (above window)
+                    float lintelStartY = window.sillHeight + window.height;
+                    float lintelHeight = storyHeight - lintelStartY;
+                    if (lintelHeight > 0.01f)
+                    {
+                        Mesh lintelMesh = GenerateWallSliceMesh(sliceLength, lintelHeight, thickness, Vector3.zero);
+                        GameObject lintelGo = new GameObject("Lintel");
+                        lintelGo.AddComponent<MeshFilter>().mesh = lintelMesh;
+                        lintelGo.AddComponent<MeshRenderer>(); // TODO: Assign material
+                        lintelGo.transform.SetParent(wallRoot.transform, false);
+                        lintelGo.transform.localPosition = new Vector3(sliceStart, lintelStartY, 0);
+                    }
+                    openingFound = true;
+                    break;
+                }
+            }
+            if (openingFound) continue;
+
+            // Check for Doors
+            foreach (DoorSpec door in relevantDoors)
+            {
+                if (sliceMidPoint >= door.position.x && sliceMidPoint < (door.position.x + door.width))
+                {
+                    // Header Slice (above door)
+                    float headerHeight = storyHeight - door.height;
+                    if (headerHeight > 0.01f)
+                    {
+                        Mesh headerMesh = GenerateWallSliceMesh(sliceLength, headerHeight, thickness, Vector3.zero);
+                        GameObject headerGo = new GameObject("Header");
+                        headerGo.AddComponent<MeshFilter>().mesh = headerMesh;
+                        headerGo.AddComponent<MeshRenderer>(); // TODO: Assign material
+                        headerGo.transform.SetParent(wallRoot.transform, false);
+                        headerGo.transform.localPosition = new Vector3(sliceStart, door.height, 0);
+                    }
+                    openingFound = true;
+                    break;
+                }
+            }
+            if (openingFound) continue;
+
+            // Check for other Openings
+            foreach (OpeningSpec opening in relevantOpenings)
+            {
+                if (sliceMidPoint >= opening.position.x && sliceMidPoint < (opening.position.x + opening.width))
+                {
+                    openingFound = true;
+                    break;
+                }
+            }
+            if (openingFound) continue;
+
+            // Solid Wall Slice
+            Mesh solidWallMesh = GenerateWallSliceMesh(sliceLength, storyHeight, thickness, Vector3.zero);
+            GameObject solidWallGo = new GameObject("SolidSlice");
+            solidWallGo.AddComponent<MeshFilter>().mesh = solidWallMesh;
+            solidWallGo.AddComponent<MeshRenderer>(); // TODO: Assign material
+            solidWallGo.transform.SetParent(wallRoot.transform, false);
+            solidWallGo.transform.localPosition = new Vector3(sliceStart, 0, 0);
+        }
+        return wallRoot;
     }
 
     private static void BuildRectangularEnclosure(RoomData stairwell,
@@ -147,7 +319,8 @@ public static class RoomBuilder
                                                   float height,
                                                   float thickness,
                                                   HashSet<string> builtKeys,
-                                                  ref int wallIndex)
+                                                  ref int wallIndex,
+                                                  HousePlanSO housePlan) // Added housePlan
     {
         Vector3 sw = stairwell.position;
         Vector3 se = stairwell.position + new Vector3(stairwell.dimensions.x, 0f, 0f);
@@ -165,7 +338,16 @@ public static class RoomBuilder
                 continue;
             }
 
-            GameObject wall = BuildWallSegment(start, end, height, thickness);
+            // Create a temporary WallSegment for BuildWallSegment
+            WallSegment tempSegment = new WallSegment
+            {
+                startPoint = start - stairwell.position, // Local start point relative to stairwell room origin
+                endPoint = end - stairwell.position,     // Local end point relative to stairwell room origin
+                isExterior = false
+                // doorIdsOnWall, windowIdsOnWall, openingIdsOnWall will be null by default, handled by BuildWallSegment
+            };
+
+            GameObject wall = BuildWallSegment(tempSegment, stairwell.position, height, thickness, housePlan);
             if (wall != null)
             {
                 wall.name = $"Wall_{stairwell.roomId}_{wallIndex}";
@@ -191,56 +373,5 @@ public static class RoomBuilder
         return $"{aStr}-{bStr}";
     }
 
-    private static void ProcessWallCutouts(WallSegment segment, string wallId, HousePlanSO plan)
-    {
-        if (plan == null)
-        {
-            return;
-        }
-
-        if (segment.doorIdsOnWall != null)
-        {
-            foreach (string id in segment.doorIdsOnWall)
-            {
-                foreach (DoorSpec spec in plan.doors)
-                {
-                    if (spec.doorId == id)
-                    {
-                        Log.Info($"Placeholder for cut-out: {spec.doorId} on wall {wallId} at position {spec.position} with size {spec.width}x{spec.height}");
-                        break;
-                    }
-                }
-            }
-        }
-
-        if (segment.windowIdsOnWall != null)
-        {
-            foreach (string id in segment.windowIdsOnWall)
-            {
-                foreach (WindowSpec spec in plan.windows)
-                {
-                    if (spec.windowId == id)
-                    {
-                        Log.Info($"Placeholder for cut-out: {spec.windowId} on wall {wallId} at position {spec.position} with size {spec.width}x{spec.height}");
-                        break;
-                    }
-                }
-            }
-        }
-
-        if (segment.openingIdsOnWall != null)
-        {
-            foreach (string id in segment.openingIdsOnWall)
-            {
-                foreach (OpeningSpec spec in plan.openings)
-                {
-                    if (spec.openingId == id)
-                    {
-                        Log.Info($"Placeholder for cut-out: {spec.openingId} on wall {wallId} at position {spec.position} with size {spec.width}x{spec.height}");
-                        break;
-                    }
-                }
-            }
-        }
-    }
+    // ProcessWallCutouts method removed
 }


### PR DESCRIPTION
…h cutouts.

I modified WallBuilder.cs and RoomBuilder.cs to implement a new wall generation strategy:

- Wall segments are now built by generating individual 'slices' between 'cut markers'.
- Cut markers are defined by the wall segment's start/end and the jambs of doors, windows, and other openings.
- Mesh is generated only for solid wall portions. Openings for doors and windows are created by skipping mesh generation for those slices.
- For windows, wall slices are generated for the sill (below the window) and the lintel (above the window).
- For doors, a header slice is generated above the door opening.
- The calculation of cut marker positions along a wall segment has been corrected to use vector projection (Vector3.Dot). This ensures accurate placement of openings regardless of the wall's orientation, using the `position` fields from `DoorSpec`, `WindowSpec` (relative to room origin), and `OpeningSpec` (relative to house origin).
- Redundant `ProcessWallCutouts` methods have been removed.
- I added the helper method `GenerateWallSliceMesh` to create individual slice meshes.