### PR TITLE
feat: Implement Scene Portal System

### DIFF
--- a/Echoes of the Hollow/Assets/Player/Movement.cs
+++ b/Echoes of the Hollow/Assets/Player/Movement.cs
@@ -1,4 +1,5 @@
 using UnityEngine;
+using UnityEngine.SceneManagement; // Required for sceneLoaded event
 
 public class Movement : MonoBehaviour
 {
@@ -14,24 +15,75 @@ public class Movement : MonoBehaviour
     [SerializeField] LayerMask groundMask;
     bool isGrounded;
 
+    void Awake()
+    {
+        // It's good practice to ensure the CharacterController is assigned.
+        if (controller == null)
+        {
+            controller = GetComponent<CharacterController>();
+        }
+        // Subscribe to the sceneLoaded event
+        SceneManager.sceneLoaded += OnSceneLoaded;
+    }
+
+    void OnDestroy()
+    {
+        // Unsubscribe when the object is destroyed to prevent memory leaks
+        SceneManager.sceneLoaded -= OnSceneLoaded;
+    }
+
+    void Start()
+    {
+        // Initial attempt to spawn at a specific point if this is the first scene load for the player
+        // or if the scene was reloaded without a portal.
+        if (PlayerSpawnManager.Instance != null)
+        {
+            PlayerSpawnManager.Instance.AttemptSpawnPlayer(gameObject);
+        }
+        else
+        {
+            Debug.LogWarning("Movement Start: PlayerSpawnManager instance not found. Player will start at default position.");
+        }
+    }
+
+    void OnSceneLoaded(Scene scene, LoadSceneMode mode)
+    {
+        Debug.Log($"Movement: Scene {scene.name} loaded. Mode: {mode}. Attempting to spawn player.");
+        if (PlayerSpawnManager.Instance != null)
+        {
+            // Disable CharacterController temporarily to allow teleportation
+            if (controller != null) controller.enabled = false;
+            PlayerSpawnManager.Instance.AttemptSpawnPlayer(gameObject);
+            if (controller != null) controller.enabled = true;
+        }
+        else
+        {
+            Debug.LogWarning($"Movement OnSceneLoaded: PlayerSpawnManager instance not found in scene {scene.name}. Player will remain at default position or last position.");
+        }
+    }
+
     private void Update (){
         isGrounded = Physics.CheckSphere(transform.position, 0.1f, groundMask);
         if (isGrounded){
             verticalVelocity.y = 0;
         }
 
-        Vector3 horizontalVelocity = (transform.right * horizontalInput.x + transform.forward * horizontalInput.y) * speed;
-        controller.Move(horizontalVelocity * Time.deltaTime);
+        // Example movement logic
+        if (controller != null && controller.enabled)
+        {
+            Vector3 horizontalVelocity = (transform.right * horizontalInput.x + transform.forward * horizontalInput.y) * speed;
+            controller.Move(horizontalVelocity * Time.deltaTime);
 
-        if (jump){
-            if (isGrounded){
-                verticalVelocity.y = Mathf.Sqrt(-2f * jumpHeight * gravity);
+            if (jump){
+                if (isGrounded){
+                    verticalVelocity.y = Mathf.Sqrt(-2f * jumpHeight * gravity);
+                }
+                jump = false;
             }
-            jump = false;
-        }
 
-        verticalVelocity.y += gravity * Time.deltaTime;
-        controller.Move(verticalVelocity * Time.deltaTime);
+            verticalVelocity.y += gravity * Time.deltaTime;
+            controller.Move(verticalVelocity * Time.deltaTime);
+        }
     }
 
     public void ReceiveInput (Vector2 _horizontalInput){

--- a/Echoes of the Hollow/Assets/Player/Movement.cs
+++ b/Echoes of the Hollow/Assets/Player/Movement.cs
@@ -51,10 +51,24 @@ public class Movement : MonoBehaviour
         Debug.Log($"Movement: Scene {scene.name} loaded. Mode: {mode}. Attempting to spawn player.");
         if (PlayerSpawnManager.Instance != null)
         {
-            // Disable CharacterController temporarily to allow teleportation
-            if (controller != null) controller.enabled = false;
-            PlayerSpawnManager.Instance.AttemptSpawnPlayer(gameObject);
-            if (controller != null) controller.enabled = true;
+            if (controller != null)
+            {
+                controller.enabled = false;
+                try
+                {
+                    PlayerSpawnManager.Instance.AttemptSpawnPlayer(gameObject);
+                }
+                finally
+                {
+                    // Ensure the controller is re-enabled even if an exception occurs
+                    controller.enabled = true;
+                }
+            }
+            else
+            {
+                // If there's no controller, just attempt to spawn
+                PlayerSpawnManager.Instance.AttemptSpawnPlayer(gameObject);
+            }
         }
         else
         {

--- a/Echoes of the Hollow/Assets/Scripts/PlayerSpawnManager.cs
+++ b/Echoes of the Hollow/Assets/Scripts/PlayerSpawnManager.cs
@@ -1,0 +1,68 @@
+using UnityEngine;
+
+public class PlayerSpawnManager : MonoBehaviour
+{
+    public static PlayerSpawnManager Instance { get; private set; }
+
+    private static int requestedSpawnPointId = -1; // -1 indicates no specific spawn point requested
+
+    void Awake()
+    {
+        if (Instance == null)
+        {
+            Instance = this;
+            DontDestroyOnLoad(gameObject); // Make this a persistent singleton
+        }
+        else if (Instance != this)
+        {
+            Destroy(gameObject); // Destroy duplicate instances
+        }
+    }
+
+    public static void RequestSpawnAt(int spawnPointId)
+    {
+        requestedSpawnPointId = spawnPointId;
+        Debug.Log($"PlayerSpawnManager: Spawn requested at ID {spawnPointId}");
+    }
+
+    // Call this method after a new scene is loaded to position the player
+    public void AttemptSpawnPlayer(GameObject playerObject)
+    {
+        if (playerObject == null)
+        {
+            Debug.LogError("PlayerSpawnManager: Player object is null.");
+            return;
+        }
+
+        if (requestedSpawnPointId != -1)
+        {
+            SpawnPoint[] spawnPoints = FindObjectsOfType<SpawnPoint>();
+            SpawnPoint targetSpawnPoint = null;
+
+            foreach (SpawnPoint sp in spawnPoints)
+            {
+                if (sp.spawnId == requestedSpawnPointId)
+                {
+                    targetSpawnPoint = sp;
+                    break;
+                }
+            }
+
+            if (targetSpawnPoint != null)
+            {
+                playerObject.transform.position = targetSpawnPoint.transform.position;
+                playerObject.transform.rotation = targetSpawnPoint.transform.rotation;
+                Debug.Log($"PlayerSpawnManager: Player spawned at {targetSpawnPoint.name} (ID: {requestedSpawnPointId}).");
+            }
+            else
+            {
+                Debug.LogWarning($"PlayerSpawnManager: No spawn point found with ID {requestedSpawnPointId} in the current scene. Player will remain at their current position or default scene start.");
+            }
+            requestedSpawnPointId = -1; // Reset after attempting to spawn
+        }
+        else
+        {
+            Debug.Log("PlayerSpawnManager: No specific spawn point requested. Player will remain at their current position or default scene start.");
+        }
+    }
+}

--- a/Echoes of the Hollow/Assets/Scripts/ScenePortal.cs
+++ b/Echoes of the Hollow/Assets/Scripts/ScenePortal.cs
@@ -1,0 +1,109 @@
+using UnityEngine;
+using UnityEngine.SceneManagement;
+using System.Collections; // Required for IEnumerator
+
+public class ScenePortal : MonoBehaviour
+{
+    public string targetSceneName;
+    public int targetSpawnPointId = 0; // Default to 0 if not specified
+    public bool unloadCurrentScene = true; // Determines if the current scene should be unloaded
+
+    private bool isLoading = false; // To prevent multiple loads
+
+    void OnTriggerEnter(Collider other)
+    {
+        if (isLoading) return; // If already loading, do nothing
+
+        if (other.CompareTag("Player")) // Make sure your player GameObject has the "Player" tag
+        {
+            Debug.Log($"ScenePortal: Player entered trigger. Target scene: {targetSceneName}, Spawn ID: {targetSpawnPointId}");
+            isLoading = true;
+
+            // Request spawn point for the player in the next scene
+            if (PlayerSpawnManager.Instance != null)
+            {
+                PlayerSpawnManager.RequestSpawnAt(targetSpawnPointId);
+            }
+            else
+            {
+                Debug.LogError("ScenePortal: PlayerSpawnManager instance not found. Make sure a PlayerSpawnManager is in the scene and initialized.");
+                isLoading = false;
+                return;
+            }
+
+            StartCoroutine(LoadTargetScene());
+        }
+    }
+
+    private IEnumerator LoadTargetScene()
+    {
+        if (string.IsNullOrEmpty(targetSceneName))
+        {
+            Debug.LogError("ScenePortal: Target scene name is not set.");
+            isLoading = false;
+            yield break;
+        }
+
+        // Start loading the target scene additively
+        AsyncOperation asyncLoad = SceneManager.LoadSceneAsync(targetSceneName, LoadSceneMode.Additive);
+
+        // Wait until the new scene is fully loaded
+        while (!asyncLoad.isDone)
+        {
+            // Here you could update a loading progress bar if you have one
+            Debug.Log($"ScenePortal: Loading scene {targetSceneName}... Progress: {asyncLoad.progress * 100}%");
+            yield return null;
+        }
+
+        Debug.Log($"ScenePortal: Scene {targetSceneName} loaded successfully.");
+
+        // Set the newly loaded scene as the active scene
+        // This is important for lighting, NavMesh, and other scene-specific settings
+        Scene targetScene = SceneManager.GetSceneByName(targetSceneName);
+        if (targetScene.IsValid())
+        {
+            SceneManager.SetActiveScene(targetScene);
+            Debug.Log($"ScenePortal: Active scene set to {targetSceneName}");
+        }
+        else
+        {
+            Debug.LogError($"ScenePortal: Could not find scene {targetSceneName} to set as active after loading.");
+            // Not returning here, as the scene is loaded, just couldn't set active.
+        }
+
+        // Unload the current scene if specified
+        if (unloadCurrentScene)
+        {
+            string currentSceneName = SceneManager.GetActiveScene().name; // Get current scene name *before* unloading
+            // It's safer to get the current scene by gameObject.scene.name if this script is part of the scene to be unloaded
+            string sceneNameToUnload = gameObject.scene.name;
+
+            if (!string.IsNullOrEmpty(sceneNameToUnload) && sceneNameToUnload != targetSceneName)
+            {
+                Debug.Log($"ScenePortal: Unloading current scene: {sceneNameToUnload}");
+                AsyncOperation asyncUnload = SceneManager.UnloadSceneAsync(sceneNameToUnload);
+                while (asyncUnload != null && !asyncUnload.isDone)
+                {
+                    Debug.Log($"ScenePortal: Unloading scene {sceneNameToUnload}... Progress: {asyncUnload.progress * 100}%");
+                    yield return null;
+                }
+                if(asyncUnload != null) // Check if operation was successful
+                   Debug.Log($"ScenePortal: Scene {sceneNameToUnload} unloaded successfully.");
+                else
+                   Debug.LogError($"ScenePortal: Failed to start unloading scene {sceneNameToUnload}.");
+
+            }
+            else if (sceneNameToUnload == targetSceneName)
+            {
+                 Debug.LogWarning($"ScenePortal: Current scene ({sceneNameToUnload}) is the same as target scene. Not unloading.");
+            }
+            else
+            {
+                Debug.LogWarning("ScenePortal: Could not determine current scene name to unload or it's invalid.");
+            }
+        }
+
+        // Reset loading flag
+        isLoading = false;
+    }
+}

--- a/Echoes of the Hollow/Assets/Scripts/SpawnPoint.cs
+++ b/Echoes of the Hollow/Assets/Scripts/SpawnPoint.cs
@@ -1,0 +1,6 @@
+using UnityEngine;
+
+public class SpawnPoint : MonoBehaviour
+{
+    public int spawnId = 0; // Default ID, should be unique within a scene for multiple spawn points
+}


### PR DESCRIPTION
Adds a robust scene portal system with the following features:

- `ScenePortal.cs`:
  - Attachable to trigger colliders.
  - Loads a specified target scene asynchronously (`LoadSceneMode.Additive`).
  - Optionally unloads the current scene for full transitions.
  - Specifies a `targetSpawnPointId` for player placement in the new scene.

- `PlayerSpawnManager.cs`:
  - Singleton manager to handle spawn requests.
  - `RequestSpawnAt(spawnPointId)`: Called by `ScenePortal` to designate where you should appear.
  - `AttemptSpawnPlayer(playerObject)`: Called by your player script after a scene loads, moving you to the requested `SpawnPoint`.
  - Persists across scene loads (`DontDestroyOnLoad`).

- `SpawnPoint.cs`:
  - Simple component to mark GameObjects as spawn locations with a unique `spawnId`.

- Modified `Player/Movement.cs`:
  - Subscribes to `SceneManager.sceneLoaded`.
  - On scene load, calls `PlayerSpawnManager.AttemptSpawnPlayer()` to position you at the correct `SpawnPoint`.
  - Temporarily disables `CharacterController` during teleportation to ensure smooth transitions.

This system allows for flexible scene transitions, supporting both additive loading (e.g., for connected areas like basements) and full scene changes, with precise control over your spawn locations.