### PR TITLE
Add TransformCaptureWindow Unity Editor tool

### DIFF
--- a/Assets/Editor/TransformCaptureWindow.cs
+++ b/Assets/Editor/TransformCaptureWindow.cs
@@ -1,0 +1,64 @@
+using UnityEditor;
+using UnityEngine;
+using System.Text;
+
+public class TransformCaptureWindow : EditorWindow
+{
+    private string generatedCode = "";
+    private Vector2 scrollPosition;
+
+    [MenuItem("House Tools/Transform Data Capturer")]
+    public static void ShowWindow()
+    {
+        GetWindow<TransformCaptureWindow>("Transform Capturer");
+    }
+
+    void OnGUI()
+    {
+        if (GUILayout.Button("Capture Selected Transforms"))
+        {
+            CaptureTransforms();
+        }
+
+        EditorGUILayout.LabelField("Generated C# Code:", EditorStyles.boldLabel);
+        scrollPosition = EditorGUILayout.BeginScrollView(scrollPosition, GUILayout.ExpandHeight(true));
+        // Make TextArea read-only by using a style with normal.textColor set to a non-editable look,
+        // or by simply not providing a way to change `generatedCode` other than CaptureTransforms.
+        // For actual read-only behavior, one might use EditorGUI.SelectableLabel.
+        // However, TextArea is fine for typical editor script usage if modification isn't intended.
+        EditorGUILayout.TextArea(generatedCode, GUILayout.ExpandHeight(true), GUILayout.ExpandWidth(true));
+        EditorGUILayout.EndScrollView();
+    }
+
+    private void CaptureTransforms()
+    {
+        StringBuilder sb = new StringBuilder();
+        GameObject[] selectedObjects = Selection.gameObjects;
+
+        if (selectedObjects.Length == 0)
+        {
+            sb.AppendLine("// No objects selected.");
+            generatedCode = sb.ToString();
+            return;
+        }
+
+        foreach (GameObject obj in selectedObjects)
+        {
+            sb.AppendLine($"// Transform data for \"{obj.name}\" (InstanceID: {obj.GetInstanceID()})");
+
+            // Position
+            Vector3 position = obj.transform.position;
+            sb.AppendLine($"Vector3 position = new Vector3({position.x.ToString("f3")}f, {position.y.ToString("f3")}f, {position.z.ToString("f3")}f);");
+
+            // Rotation (World Euler Angles)
+            Vector3 eulerAngles = obj.transform.eulerAngles;
+            sb.AppendLine($"Quaternion rotation = Quaternion.Euler({eulerAngles.x.ToString("f1")}f, {eulerAngles.y.ToString("f1")}f, {eulerAngles.z.ToString("f1")}f); // World rotation");
+
+            // Scale (Local)
+            Vector3 scale = obj.transform.localScale;
+            sb.AppendLine($"Vector3 scale = new Vector3({scale.x.ToString("f3")}f, {scale.y.ToString("f3")}f, {scale.z.ToString("f3")}f); // Local scale");
+            sb.AppendLine(); // Add a blank line for readability between objects
+        }
+        generatedCode = sb.ToString();
+    }
+}


### PR DESCRIPTION
This commit introduces a new Editor Window accessible via "House Tools/Transform Data Capturer".

Features:
- Allows you to select one or more GameObjects in the scene.
- Clicking "Capture Selected Transforms" generates C# code representing the world position, world rotation (Euler angles), and local scale for each selected object.
- Position and scale values are formatted to 3 decimal places.
- Rotation Euler angles are formatted to 1 decimal place.
- The generated code is displayed in a read-only, scrollable text area for easy copying.
- Handles cases where no objects are selected.

This tool aids in quickly extracting transform data for use in scripts or for scene setup.