### PR TITLE
feat: Implement contextual house component formatting in TransformCap…

### DIFF
--- a/Assets/Editor/TransformCaptureWindow.cs
+++ b/Assets/Editor/TransformCaptureWindow.cs
@@ -5,8 +5,11 @@ using System.Globalization; // Add this line
 
 public class TransformCaptureWindow : EditorWindow
 {
+    public enum HouseComponentType { Unknown, Room, Wall, Door, Window, Foundation, Roof, ProceduralHouseRoot }
+
     private string generatedCode = "";
     private Vector2 scrollPosition;
+    private bool useContextualFormatting = false; // Added field
 
     [MenuItem("House Tools/Transform Data Capturer")]
     public static void ShowWindow()
@@ -16,6 +19,9 @@ public class TransformCaptureWindow : EditorWindow
 
     void OnGUI()
     {
+        // Add this before the capture button
+        useContextualFormatting = EditorGUILayout.Toggle("Use Contextual House Formatting", useContextualFormatting);
+
         if (GUILayout.Button("Capture Selected Transforms"))
         {
             CaptureTransforms();
@@ -45,21 +51,117 @@ public class TransformCaptureWindow : EditorWindow
 
         foreach (GameObject obj in selectedObjects)
         {
-            sb.AppendLine($"// Transform data for \"{obj.name}\" (InstanceID: {obj.GetInstanceID()})");
-
-            // Position
-            Vector3 position = obj.transform.position;
-            sb.AppendLine($"Vector3 position = new Vector3({position.x.ToString("f3", CultureInfo.InvariantCulture)}f, {position.y.ToString("f3", CultureInfo.InvariantCulture)}f, {position.z.ToString("f3", CultureInfo.InvariantCulture)}f);");
-
-            // Rotation (World Euler Angles)
-            Vector3 eulerAngles = obj.transform.eulerAngles;
-            sb.AppendLine($"Quaternion rotation = Quaternion.Euler({eulerAngles.x.ToString("f1", CultureInfo.InvariantCulture)}f, {eulerAngles.y.ToString("f1", CultureInfo.InvariantCulture)}f, {eulerAngles.z.ToString("f1", CultureInfo.InvariantCulture)}f); // World rotation");
-
-            // Scale (Local)
-            Vector3 scale = obj.transform.localScale;
-            sb.AppendLine($"Vector3 scale = new Vector3({scale.x.ToString("f3", CultureInfo.InvariantCulture)}f, {scale.y.ToString("f3", CultureInfo.InvariantCulture)}f, {scale.z.ToString("f3", CultureInfo.InvariantCulture)}f); // Local scale");
-            sb.AppendLine();
+            if (useContextualFormatting)
+            {
+                HouseComponentType componentType = DetectComponentType(obj);
+                switch (componentType)
+                {
+                    case HouseComponentType.Room:
+                        sb.AppendLine(FormatAsRoomData(obj));
+                        break;
+                    case HouseComponentType.Wall:
+                        sb.AppendLine(FormatAsWallSegment(obj));
+                        break;
+                    case HouseComponentType.Door:
+                        sb.AppendLine(FormatAsDoorSpec(obj));
+                        break;
+                    case HouseComponentType.Window:
+                        sb.AppendLine(FormatAsWindowSpec(obj));
+                        break;
+                    case HouseComponentType.Foundation:
+                    case HouseComponentType.Roof:
+                    case HouseComponentType.ProceduralHouseRoot:
+                    case HouseComponentType.Unknown:
+                    default:
+                        sb.AppendLine($"// Detected {componentType} \"{obj.name}\" - Using generic transform output.");
+                        // Generic transform output (existing code)
+                        sb.AppendLine($"// Transform data for \"{obj.name}\" (InstanceID: {obj.GetInstanceID()})");
+                        Vector3 position = obj.transform.position;
+                        sb.AppendLine($"Vector3 position = new Vector3({position.x.ToString("f3", CultureInfo.InvariantCulture)}f, {position.y.ToString("f3", CultureInfo.InvariantCulture)}f, {position.z.ToString("f3", CultureInfo.InvariantCulture)}f);");
+                        Vector3 eulerAngles = obj.transform.eulerAngles;
+                        sb.AppendLine($"Quaternion rotation = Quaternion.Euler({eulerAngles.x.ToString("f1", CultureInfo.InvariantCulture)}f, {eulerAngles.y.ToString("f1", CultureInfo.InvariantCulture)}f, {eulerAngles.z.ToString("f1", CultureInfo.InvariantCulture)}f); // World rotation");
+                        Vector3 scale = obj.transform.localScale;
+                        sb.AppendLine($"Vector3 scale = new Vector3({scale.x.ToString("f3", CultureInfo.InvariantCulture)}f, {scale.y.ToString("f3", CultureInfo.InvariantCulture)}f, {scale.z.ToString("f3", CultureInfo.InvariantCulture)}f); // Local scale");
+                        sb.AppendLine();
+                        break;
+                }
+            }
+            else
+            {
+                // Original generic transform output
+                sb.AppendLine($"// Transform data for \"{obj.name}\" (InstanceID: {obj.GetInstanceID()})");
+                Vector3 position = obj.transform.position;
+                sb.AppendLine($"Vector3 position = new Vector3({position.x.ToString("f3", CultureInfo.InvariantCulture)}f, {position.y.ToString("f3", CultureInfo.InvariantCulture)}f, {position.z.ToString("f3", CultureInfo.InvariantCulture)}f);");
+                Vector3 eulerAngles = obj.transform.eulerAngles;
+                sb.AppendLine($"Quaternion rotation = Quaternion.Euler({eulerAngles.x.ToString("f1", CultureInfo.InvariantCulture)}f, {eulerAngles.y.ToString("f1", CultureInfo.InvariantCulture)}f, {eulerAngles.z.ToString("f1", CultureInfo.InvariantCulture)}f); // World rotation");
+                Vector3 scale = obj.transform.localScale;
+                sb.AppendLine($"Vector3 scale = new Vector3({scale.x.ToString("f3", CultureInfo.InvariantCulture)}f, {scale.y.ToString("f3", CultureInfo.InvariantCulture)}f, {scale.z.ToString("f3", CultureInfo.InvariantCulture)}f); // Local scale");
+                sb.AppendLine();
+            }
         }
         generatedCode = sb.ToString();
+    }
+
+    private HouseComponentType DetectComponentType(GameObject obj)
+    {
+        if (obj.name == "ProceduralHouse_Generated") return HouseComponentType.ProceduralHouseRoot;
+        if (obj.name == "Foundation") return HouseComponentType.Foundation;
+        if (obj.name.StartsWith("Roof_")) return HouseComponentType.Roof;
+        if (obj.name.StartsWith("Wall_")) return HouseComponentType.Wall;
+        if (obj.name.StartsWith("Door_")) return HouseComponentType.Door;
+        if (obj.name.StartsWith("Window_")) return HouseComponentType.Window;
+
+        if (obj.GetComponent<RoomIdentifier>() != null) return HouseComponentType.Room;
+        if (obj.name.Contains("Room")) return HouseComponentType.Room;
+
+        return HouseComponentType.Unknown;
+    }
+
+    private GameObject GetRoomContext(GameObject obj)
+    {
+        if (obj == null) return null;
+
+        // Check if the object itself is a room
+        if (DetectComponentType(obj) == HouseComponentType.Room)
+        {
+            return obj;
+        }
+
+        // Traverse up the hierarchy
+        Transform currentParent = obj.transform.parent;
+        while (currentParent != null)
+        {
+            if (DetectComponentType(currentParent.gameObject) == HouseComponentType.Room)
+            {
+                return currentParent.gameObject;
+            }
+            currentParent = currentParent.parent;
+        }
+
+        return null; // No room context found
+    }
+
+    private string FormatAsRoomData(GameObject obj)
+    {
+        // TODO: Implement full RoomData formatting
+        return $"// Detected Room: {obj.name} - RoomData formatting pending.\n";
+    }
+
+    private string FormatAsWallSegment(GameObject obj)
+    {
+        // TODO: Implement full WallSegment formatting
+        return $"// Detected Wall: {obj.name} - WallSegment formatting pending.\n";
+    }
+
+    private string FormatAsDoorSpec(GameObject obj)
+    {
+        // TODO: Implement full DoorSpec formatting
+        return $"// Detected Door: {obj.name} - DoorSpec formatting pending.\n";
+    }
+
+    private string FormatAsWindowSpec(GameObject obj)
+    {
+        // TODO: Implement full WindowSpec formatting
+        return $"// Detected Window: {obj.name} - WindowSpec formatting pending.\n";
     }
 }

--- a/Assets/Scripts/RoomIdentifier.cs
+++ b/Assets/Scripts/RoomIdentifier.cs
@@ -1,0 +1,6 @@
+using UnityEngine;
+
+public class RoomIdentifier : MonoBehaviour
+{
+    // Placeholder class for room identification
+}


### PR DESCRIPTION
…tureWindow

Adds the ability to detect and apply specialized formatting for common house components.

Key changes:
- Defined `HouseComponentType` enum for various component types (Room, Wall, Door, Window, etc.).
- Implemented `DetectComponentType(GameObject)` to identify components based on name and (eventually) component presence. Created a placeholder `RoomIdentifier` MonoBehaviour.
- Added a "Use Contextual House Formatting" checkbox in the TransformCaptureWindow UI.
- Implemented `GetRoomContext(GameObject)` to find the parent room of a selected object.
- Added placeholder formatting methods: `FormatAsRoomData`, `FormatAsWallSegment`, `FormatAsDoorSpec`, `FormatAsWindowSpec`.
- Modified `CaptureTransforms` to use the new detection and formatting logic when the contextual formatting option is enabled. Objects not specifically handled or when the option is disabled will use the generic transform output.