### PR TITLE
Okay, I've added the ability to convert coordinate spaces in the `Tra…

### DIFF
--- a/Assets/Editor/TransformCaptureWindow.cs
+++ b/Assets/Editor/TransformCaptureWindow.cs
@@ -6,9 +6,11 @@ using System.Globalization; // Add this line
 public class TransformCaptureWindow : EditorWindow
 {
     public enum HouseComponentType { Unknown, Room, Wall, Door, Window, Foundation, Roof, ProceduralHouseRoot }
+    public enum CoordinateSpaceSetting { World, RoomRelative, WallRelative }
 
     private string generatedCode = "";
     private Vector2 scrollPosition;
+    private CoordinateSpaceSetting selectedCoordinateSpace = CoordinateSpaceSetting.World;
     private bool useContextualFormatting = false; // Added field
 
     [MenuItem("House Tools/Transform Data Capturer")]
@@ -19,6 +21,7 @@ public class TransformCaptureWindow : EditorWindow
 
     void OnGUI()
     {
+        selectedCoordinateSpace = (CoordinateSpaceSetting)EditorGUILayout.EnumPopup("Coordinate Space:", selectedCoordinateSpace);
         // Add this before the capture button
         useContextualFormatting = EditorGUILayout.Toggle("Use Contextual House Formatting", useContextualFormatting);
 
@@ -76,8 +79,60 @@ public class TransformCaptureWindow : EditorWindow
                         sb.AppendLine($"// Detected {componentType} \"{obj.name}\" - Using generic transform output.");
                         // Generic transform output (existing code)
                         sb.AppendLine($"// Transform data for \"{obj.name}\" (InstanceID: {obj.GetInstanceID()})");
-                        Vector3 position = obj.transform.position;
-                        sb.AppendLine($"Vector3 position = new Vector3({position.x.ToString("f3", CultureInfo.InvariantCulture)}f, {position.y.ToString("f3", CultureInfo.InvariantCulture)}f, {position.z.ToString("f3", CultureInfo.InvariantCulture)}f);");
+                        // --- Start of new position logic for generic path ---
+                        Vector3 worldPosition = obj.transform.position;
+                        Vector3 positionToOutput = worldPosition;
+                        string positionComment = " // Position (World Space)";
+
+                        switch (selectedCoordinateSpace)
+                        {
+                            case CoordinateSpaceSetting.RoomRelative:
+                                GameObject roomObject = GetRoomContext(obj);
+                                if (roomObject != null)
+                                {
+                                    Vector3 roomOrigin = GetRoomOrigin(obj); // GetRoomOrigin itself handles warning if roomObject is null via GetRoomContext
+                                    positionToOutput = ConvertToRoomRelative(worldPosition, roomOrigin);
+                                    positionComment = $" // Position (Room Relative to '{roomObject.name}')";
+                                }
+                                else if (obj.transform.parent != null)
+                                {
+                                    // Fallback to parent if no room context
+                                    Vector3 parentOrigin = obj.transform.parent.position;
+                                    positionToOutput = ConvertToRoomRelative(worldPosition, parentOrigin);
+                                    positionComment = $" // Position (Relative to parent '{obj.transform.parent.name}')";
+                                    Debug.LogWarning($"'{obj.name}' (Generic): RoomRelative selected, no room context. Outputting relative to parent '{obj.transform.parent.name}'.");
+                                }
+                                else
+                                {
+                                    // No room, no parent
+                                    positionComment = " // Position (World Space - RoomRelative selected, but no Room Context or parent found)";
+                                    Debug.LogWarning($"'{obj.name}' (Generic): RoomRelative selected, but no Room Context or parent found. Defaulting to World Space.");
+                                }
+                                break;
+
+                            case CoordinateSpaceSetting.WallRelative:
+                                if (obj.transform.parent != null)
+                                {
+                                    // Use parent as the wall/reference transform
+                                    positionToOutput = ConvertToWallRelative(worldPosition, obj.transform.parent);
+                                    positionComment = $" // Position (Relative to parent '{obj.transform.parent.name}' as wall context)";
+                                    // No specific warning here as this is the defined fallback for generic WallRelative
+                                }
+                                else
+                                {
+                                    // No parent to use as reference
+                                    positionComment = " // Position (World Space - WallRelative selected, but no parent found for relative conversion)";
+                                    Debug.LogWarning($"'{obj.name}' (Generic): WallRelative selected, but no parent found. Defaulting to World Space.");
+                                }
+                                break;
+
+                            case CoordinateSpaceSetting.World:
+                            default:
+                                // Position is already worldPosition, comment is already set
+                                break;
+                        }
+                        sb.AppendLine($"Vector3 position = new Vector3({positionToOutput.x.ToString("f3", CultureInfo.InvariantCulture)}f, {positionToOutput.y.ToString("f3", CultureInfo.InvariantCulture)}f, {positionToOutput.z.ToString("f3", CultureInfo.InvariantCulture)}f);{positionComment}");
+                        // --- End of new position logic for generic path ---
                         Vector3 eulerAngles = obj.transform.eulerAngles;
                         sb.AppendLine($"Quaternion rotation = Quaternion.Euler({eulerAngles.x.ToString("f1", CultureInfo.InvariantCulture)}f, {eulerAngles.y.ToString("f1", CultureInfo.InvariantCulture)}f, {eulerAngles.z.ToString("f1", CultureInfo.InvariantCulture)}f); // World rotation");
                         Vector3 scale = obj.transform.localScale;
@@ -90,8 +145,60 @@ public class TransformCaptureWindow : EditorWindow
             {
                 // Original generic transform output
                 sb.AppendLine($"// Transform data for \"{obj.name}\" (InstanceID: {obj.GetInstanceID()})");
-                Vector3 position = obj.transform.position;
-                sb.AppendLine($"Vector3 position = new Vector3({position.x.ToString("f3", CultureInfo.InvariantCulture)}f, {position.y.ToString("f3", CultureInfo.InvariantCulture)}f, {position.z.ToString("f3", CultureInfo.InvariantCulture)}f);");
+                // --- Start of new position logic for generic path ---
+                Vector3 worldPosition = obj.transform.position;
+                Vector3 positionToOutput = worldPosition;
+                string positionComment = " // Position (World Space)";
+
+                switch (selectedCoordinateSpace)
+                {
+                    case CoordinateSpaceSetting.RoomRelative:
+                        GameObject roomObject = GetRoomContext(obj);
+                        if (roomObject != null)
+                        {
+                            Vector3 roomOrigin = GetRoomOrigin(obj); // GetRoomOrigin itself handles warning if roomObject is null via GetRoomContext
+                            positionToOutput = ConvertToRoomRelative(worldPosition, roomOrigin);
+                            positionComment = $" // Position (Room Relative to '{roomObject.name}')";
+                        }
+                        else if (obj.transform.parent != null)
+                        {
+                            // Fallback to parent if no room context
+                            Vector3 parentOrigin = obj.transform.parent.position;
+                            positionToOutput = ConvertToRoomRelative(worldPosition, parentOrigin);
+                            positionComment = $" // Position (Relative to parent '{obj.transform.parent.name}')";
+                            Debug.LogWarning($"'{obj.name}' (Generic): RoomRelative selected, no room context. Outputting relative to parent '{obj.transform.parent.name}'.");
+                        }
+                        else
+                        {
+                            // No room, no parent
+                            positionComment = " // Position (World Space - RoomRelative selected, but no Room Context or parent found)";
+                            Debug.LogWarning($"'{obj.name}' (Generic): RoomRelative selected, but no Room Context or parent found. Defaulting to World Space.");
+                        }
+                        break;
+
+                    case CoordinateSpaceSetting.WallRelative:
+                        if (obj.transform.parent != null)
+                        {
+                            // Use parent as the wall/reference transform
+                            positionToOutput = ConvertToWallRelative(worldPosition, obj.transform.parent);
+                            positionComment = $" // Position (Relative to parent '{obj.transform.parent.name}' as wall context)";
+                            // No specific warning here as this is the defined fallback for generic WallRelative
+                        }
+                        else
+                        {
+                            // No parent to use as reference
+                            positionComment = " // Position (World Space - WallRelative selected, but no parent found for relative conversion)";
+                            Debug.LogWarning($"'{obj.name}' (Generic): WallRelative selected, but no parent found. Defaulting to World Space.");
+                        }
+                        break;
+
+                    case CoordinateSpaceSetting.World:
+                    default:
+                        // Position is already worldPosition, comment is already set
+                        break;
+                }
+                sb.AppendLine($"Vector3 position = new Vector3({positionToOutput.x.ToString("f3", CultureInfo.InvariantCulture)}f, {positionToOutput.y.ToString("f3", CultureInfo.InvariantCulture)}f, {positionToOutput.z.ToString("f3", CultureInfo.InvariantCulture)}f);{positionComment}");
+                // --- End of new position logic for generic path ---
                 Vector3 eulerAngles = obj.transform.eulerAngles;
                 sb.AppendLine($"Quaternion rotation = Quaternion.Euler({eulerAngles.x.ToString("f1", CultureInfo.InvariantCulture)}f, {eulerAngles.y.ToString("f1", CultureInfo.InvariantCulture)}f, {eulerAngles.z.ToString("f1", CultureInfo.InvariantCulture)}f); // World rotation");
                 Vector3 scale = obj.transform.localScale;
@@ -141,6 +248,92 @@ public class TransformCaptureWindow : EditorWindow
         return null; // No room context found
     }
 
+    private Vector3 GetRoomOrigin(GameObject objInRoom)
+    {
+        GameObject roomObject = GetRoomContext(objInRoom);
+        if (roomObject != null)
+        {
+            // Assuming the room's GameObject position is the desired origin.
+            // If specific bounds (e.g., South-West corner) are needed, this logic would
+            // need to be more complex, potentially involving Mesh Renderers or Colliders.
+            return roomObject.transform.position;
+        }
+        else
+        {
+            Debug.LogWarning($"No room context found for '{objInRoom.name}'. Defaulting room origin to Vector3.zero.");
+            return Vector3.zero;
+        }
+    }
+
+    private Vector3 ConvertToRoomRelative(Vector3 worldPosition, Vector3 roomWorldOrigin)
+    {
+        return worldPosition - roomWorldOrigin;
+    }
+
+    private Vector3 ConvertToWallRelative(Vector3 worldPosition, Transform wallSegmentRootTransform)
+    {
+        if (wallSegmentRootTransform == null)
+        {
+            Debug.LogWarning("Attempted to convert to wall relative space with a null wallSegmentRootTransform. Returning world position.");
+            return worldPosition; // Or handle as an error, e.g., return Vector3.zero or throw exception
+        }
+        return wallSegmentRootTransform.InverseTransformPoint(worldPosition);
+    }
+
+    private string GetProcessedPositionString(GameObject obj, Vector3 worldPosition, string componentTypeName)
+    {
+        Vector3 positionToOutput = worldPosition;
+        string positionComment = ""; // To add context like "(World Space)" or "(Room Relative)"
+
+        switch (selectedCoordinateSpace)
+        {
+            case CoordinateSpaceSetting.RoomRelative:
+                GameObject roomObject = GetRoomContext(obj);
+                if (roomObject != null)
+                {
+                    Vector3 roomOrigin = GetRoomOrigin(obj); // obj or roomObject should both work if obj is inside
+                    positionToOutput = ConvertToRoomRelative(worldPosition, roomOrigin);
+                    positionComment = $" // {componentTypeName} Position (Room Relative to '{roomObject.name}')";
+                }
+                else
+                {
+                    Debug.LogWarning($"'{obj.name}' ({componentTypeName}): RoomRelative selected, but no room context found. Defaulting to World Space.");
+                    positionComment = $" // {componentTypeName} Position (World Space - No Room Context Found)";
+                }
+                break;
+
+            case CoordinateSpaceSetting.WallRelative:
+                Transform parentWallTransform = null;
+                if (obj.transform.parent != null)
+                {
+                    // Assuming the direct parent is the wall.
+                    // More robust wall finding might be needed if hierarchy is deeper/complex.
+                    if (DetectComponentType(obj.transform.parent.gameObject) == HouseComponentType.Wall)
+                    {
+                        parentWallTransform = obj.transform.parent;
+                    }
+                }
+
+                if (parentWallTransform != null)
+                {
+                    positionToOutput = ConvertToWallRelative(worldPosition, parentWallTransform);
+                    positionComment = $" // {componentTypeName} Position (Wall Relative to '{parentWallTransform.name}')";
+                }
+                else
+                {
+                    Debug.LogWarning($"'{obj.name}' ({componentTypeName}): WallRelative selected, but no parent wall found or parent is not a Wall. Defaulting to World Space.");
+                    positionComment = $" // {componentTypeName} Position (World Space - No Parent Wall Found)";
+                }
+                break;
+
+            case CoordinateSpaceSetting.World:
+            default:
+                positionComment = $" // {componentTypeName} Position (World Space)";
+                break;
+        }
+        return $"Vector3 position = new Vector3({positionToOutput.x.ToString("f3", CultureInfo.InvariantCulture)}f, {positionToOutput.y.ToString("f3", CultureInfo.InvariantCulture)}f, {positionToOutput.z.ToString("f3", CultureInfo.InvariantCulture)}f);{positionComment}";
+    }
+
     private string FormatAsRoomData(GameObject obj)
     {
         // TODO: Implement full RoomData formatting
@@ -155,13 +348,41 @@ public class TransformCaptureWindow : EditorWindow
 
     private string FormatAsDoorSpec(GameObject obj)
     {
-        // TODO: Implement full DoorSpec formatting
-        return $"// Detected Door: {obj.name} - DoorSpec formatting pending.\n";
+        StringBuilder sb = new StringBuilder();
+        sb.AppendLine($"// Door Specification for \"{obj.name}\" (InstanceID: {obj.GetInstanceID()})");
+
+        Vector3 worldPosition = obj.transform.position;
+        sb.AppendLine(GetProcessedPositionString(obj, worldPosition, "Door"));
+
+        // Retain existing rotation and scale logic (world rotation, local scale)
+        Vector3 eulerAngles = obj.transform.eulerAngles;
+        sb.AppendLine($"Quaternion rotation = Quaternion.Euler({eulerAngles.x.ToString("f1", CultureInfo.InvariantCulture)}f, {eulerAngles.y.ToString("f1", CultureInfo.InvariantCulture)}f, {eulerAngles.z.ToString("f1", CultureInfo.InvariantCulture)}f); // World rotation");
+        Vector3 scale = obj.transform.localScale;
+        sb.AppendLine($"Vector3 scale = new Vector3({scale.x.ToString("f3", CultureInfo.InvariantCulture)}f, {scale.y.ToString("f3", CultureInfo.InvariantCulture)}f, {scale.z.ToString("f3", CultureInfo.InvariantCulture)}f); // Local scale");
+
+        // TODO: Add other Door-specific properties here if needed in future
+        sb.AppendLine("// Add other Door-specific properties here");
+        sb.AppendLine();
+        return sb.ToString();
     }
 
     private string FormatAsWindowSpec(GameObject obj)
     {
-        // TODO: Implement full WindowSpec formatting
-        return $"// Detected Window: {obj.name} - WindowSpec formatting pending.\n";
+        StringBuilder sb = new StringBuilder();
+        sb.AppendLine($"// Window Specification for \"{obj.name}\" (InstanceID: {obj.GetInstanceID()})");
+
+        Vector3 worldPosition = obj.transform.position;
+        sb.AppendLine(GetProcessedPositionString(obj, worldPosition, "Window"));
+
+        // Retain existing rotation and scale logic (world rotation, local scale)
+        Vector3 eulerAngles = obj.transform.eulerAngles;
+        sb.AppendLine($"Quaternion rotation = Quaternion.Euler({eulerAngles.x.ToString("f1", CultureInfo.InvariantCulture)}f, {eulerAngles.y.ToString("f1", CultureInfo.InvariantCulture)}f, {eulerAngles.z.ToString("f1", CultureInfo.InvariantCulture)}f); // World rotation");
+        Vector3 scale = obj.transform.localScale;
+        sb.AppendLine($"Vector3 scale = new Vector3({scale.x.ToString("f3", CultureInfo.InvariantCulture)}f, {scale.y.ToString("f3", CultureInfo.InvariantCulture)}f, {scale.z.ToString("f3", CultureInfo.InvariantCulture)}f); // Local scale");
+
+        // TODO: Add other Window-specific properties here
+        sb.AppendLine("// Add other Window-specific properties here");
+        sb.AppendLine();
+        return sb.ToString();
     }
 }


### PR DESCRIPTION
…nsformCaptureWindow`.

Here's a summary of what I did:

I've implemented functionality to capture transform data in different coordinate spaces (World, RoomRelative, WallRelative) within the `TransformCaptureWindow` editor script.

Key changes:
- I added a `CoordinateSpaceSetting` enum (World, RoomRelative, WallRelative).
- I added a dropdown UI in the editor window for you to select the desired coordinate space.
- I implemented some helper methods:
    - `GetRoomOrigin(GameObject objInRoom)`: This determines a room's origin for relative calculations.
    - `ConvertToRoomRelative(Vector3 worldPosition, Vector3 roomWorldOrigin)`: This converts a world position to be relative to the room.
    - `ConvertToWallRelative(Vector3 worldPosition, Transform wallSegmentRootTransform)`: This converts a world position to be relative to a wall.
- I updated the `CaptureTransforms()` method:
    - For contextual formatting (like for Doors and Windows): The position output is now converted based on the coordinate space you select. I've also included warnings and fallbacks to world space if the necessary contexts (like a room or wall) aren't found.
    - For generic transform output: The position output also respects the selected coordinate space. I'll try to use the room context or the parent object's context for relative calculations, with fallbacks to world space and warnings if needed.
- The output C# code now includes comments indicating the coordinate space used for the position and any fallbacks that occurred.
- Rotation and scale will remain in their original spaces (world rotation, local scale) as you requested.