### PR TITLE
I've made some changes to address the CS0246 error regarding `Transfo…

### DIFF
--- a/Assets/Editor/EchoesEditorUtils.asmdef
+++ b/Assets/Editor/EchoesEditorUtils.asmdef
@@ -1,0 +1,16 @@
+{
+    "name": "EchoesEditorUtils",
+    "rootNamespace": "",
+    "references": [],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Echoes of the Hollow/Assets/Test/Editor/EchoesEditorTests.asmdef
+++ b/Echoes of the Hollow/Assets/Test/Editor/EchoesEditorTests.asmdef
@@ -1,0 +1,22 @@
+{
+    "name": "EchoesEditorTests",
+    "rootNamespace": "",
+    "references": [
+        "EchoesEditorUtils"
+    ],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": true,
+    "precompiledReferences": [
+        "nunit.framework.dll"
+    ],
+    "autoReferenced": false,
+    "defineConstraints": [
+        "UNITY_INCLUDE_TESTS"
+    ],
+    "versionDefines": [],
+    "noEngineReferences": false
+}


### PR DESCRIPTION
…rmCaptureWindow` in your tests.

Here's what I did:

I introduced Assembly Definition files (.asmdef) to better manage how your code compiles and how different parts of your editor utilities and tests depend on each other.

Specifically:
- I created `Assets/Editor/EchoesEditorUtils.asmdef` for your main editor scripts, including `TransformCaptureWindow.cs`. This assembly is now named `EchoesEditorUtils`.
- I created `Echoes of the Hollow/Assets/Test/Editor/EchoesEditorTests.asmdef` for your editor test scripts, like `TransformCaptureTests.cs`. This assembly is named `EchoesEditorTests`.
- I then added a reference from `EchoesEditorTests.asmdef` to `EchoesEditorUtils`. This allows your tests to correctly access the utility classes.

This should resolve the CS0246 error. The problem was that `TransformCaptureWindow` couldn't be found by `TransformCaptureTests.cs` because of how compilation was handled separately for the `Assets/Editor` directory and the `Echoes of the Hollow/Assets/Test/Editor` directory.