### PR TITLE
Fix: Resolve multiple C# compiler errors

### DIFF
--- a/Echoes of the Hollow/Assets/Editor/EditorScripts.asmdef
+++ b/Echoes of the Hollow/Assets/Editor/EditorScripts.asmdef
@@ -1,0 +1,18 @@
+{
+    "name": "EditorScripts",
+    "rootNamespace": "",
+    "references": [
+        "HousePlan"
+    ],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Echoes of the Hollow/Assets/Editor/HousePlanDiffer.cs
+++ b/Echoes of the Hollow/Assets/Editor/HousePlanDiffer.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq;
 using UnityEngine; // For Vector3, etc. if used in data structures, though HousePlanSO types should be primary
 using UnityEditor; // For AssetDatabase if used for loading
 // It's good practice to include HousePlanSO related types if they are directly used or referenced.

--- a/Echoes of the Hollow/Assets/HousePlan/HousePlan.asmdef
+++ b/Echoes of the Hollow/Assets/HousePlan/HousePlan.asmdef
@@ -1,0 +1,14 @@
+{
+    "name": "HousePlan",
+    "rootNamespace": "",
+    "references": [],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Echoes of the Hollow/Assets/Test/Editor/Tests/EditorTests.asmdef
+++ b/Echoes of the Hollow/Assets/Test/Editor/Tests/EditorTests.asmdef
@@ -1,0 +1,30 @@
+{
+    "name": "EditorTests",
+    "rootNamespace": "",
+    "references": [
+        "HousePlan",
+        "EditorScripts"
+    ],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": true,
+    "precompiledReferences": [
+        "nunit.framework.dll"
+    ],
+    "autoReferenced": false,
+    "defineConstraints": [],
+    "versionDefines": [
+        {
+            "name": "com.unity.test-framework",
+            "expression": "",
+            "define": "UNITY_INCLUDE_TESTS"
+        }
+    ],
+    "noEngineReferences": false,
+    "optionalUnityReferences": [
+        "TestAssemblies"
+    ]
+}


### PR DESCRIPTION
This commit addresses a range of C# compiler errors including type mismatches, missing members, and incorrect type references.

Key changes:
- I resolved CS1503 type conversion errors for `HousePlanSO` by removing duplicate definitions in `TransformCaptureWindow.cs` and introducing Assembly Definition Files (`.asmdef`) for `HousePlan`, `EditorScripts`, and `EditorTests`. This ensures consistent type resolution across editor assemblies and also addresses CS1061 for `OpeningSpec.passthroughLedgeDepth` and visibility issues for `WallSegmentAnalyzer.AnalyzedWallData`.
- I fixed CS1061 errors for LINQ methods in `HousePlanDiffer.cs` by adding `using System.Linq;`.
- I addressed CS0426 for `AnalyzedWallData` by ensuring proper assembly referencing through `.asmdef` files.
- I resolved CS0246 for missing `ComponentType` in `TransformCaptureWindow.cs` by defining the required enum.
- I corrected CS0117 for non-existent `WallSegmentAnalyzer.OpeningTypeEnum` in `TransformCaptureWindow.cs` by updating logic to use boolean fields from `WallSegmentAnalyzer.OpeningData` and map to the global `OpeningType` enum.
- I fixed CS1729 and CS1061 for `DiffResultSet` in `TransformCaptureWindow.cs` by defining a new local `DiffResultSet` class with the expected constructor and members for the `ExecuteUpdateOnAsset` method.