### PR TITLE
Fix: Correct house component detection and Foyer data generation

### DIFF
--- a/Echoes of the Hollow/Assets/Editor/BlueprintImporter.cs
+++ b/Echoes of the Hollow/Assets/Editor/BlueprintImporter.cs
@@ -409,46 +409,54 @@ public static class BlueprintImporter
         // plan.doors.Add(new DoorSpec { doorId = "ExampleFoyerToGarage", ... }); // Removed
         // plan.openings.Add(new OpeningSpec { openingId = "ExampleFoyerToLiving", ... }); // Removed
 
-        // Create "FrontDoor"
-        plan.doors.Add(new DoorSpec {
-            doorId = "FrontDoor",
-            type = DoorType.Hinged,
-            width = 3f * FEET_TO_METERS, // 3 feet wide
-            height = (6f + 8f/12f) * FEET_TO_METERS, // 6'8" standard height
-            // Foyer's south wall is at foyerPos.z. Door centered on Foyer's width.
-            position = new Vector3(foyerPos.x + foyerWidth / 2f, foyerPos.y, foyerPos.z),
-            wallId = "Wall_Foyer_S",
-            swingDirection = SwingDirection.InwardSouth, // Test expects InwardSouth
-            connectsRoomA_Id = "Foyer",
-            connectsRoomB_Id = "CoveredEntry"
-        });
+        // Locate or Create "FrontDoor"
+        DoorSpec frontDoor = plan.doors.Find(d => d.doorId == "FrontDoor");
+        if (frontDoor == null)
+        {
+            frontDoor = new DoorSpec();
+            plan.doors.Add(frontDoor);
+        }
+        frontDoor.doorId = "FrontDoor";
+        frontDoor.type = DoorType.Hinged;
+        frontDoor.width = 0.9144f; // Approximately 3 feet
+        frontDoor.height = (6f + 8f/12f) * FEET_TO_METERS; // 6'8" standard height
+        frontDoor.position = new Vector3(foyerPos.x + foyerWidth / 2f, foyerPos.y, foyerPos.z); // Centered on Foyer's south wall
+        frontDoor.wallId = "Wall_Foyer_S";
+        frontDoor.swingDirection = SwingDirection.InwardSouth;
+        frontDoor.connectsRoomA_Id = "Foyer";
+        frontDoor.connectsRoomB_Id = "CoveredEntry";
 
-        // Create Foyer to Garage Door
-        plan.doors.Add(new DoorSpec {
-            doorId = "FoyerToGarageDoor",
-            type = DoorType.Hinged,
-            width = (2f + 8f/12f) * FEET_TO_METERS, // 2'8"
-            height = (6f + 8f/12f) * FEET_TO_METERS, // 6'8"
-            // Position on Foyer's west wall (foyerPos.x), partway along its depth.
-            // Example: centered on the typical 6ft depth of the foyer, but avoiding corners.
-            position = new Vector3(foyerPos.x, foyerPos.y, foyerPos.z + foyerDepth / 2f),
-            wallId = "Wall_Foyer_W",
-            connectsRoomA_Id = "Foyer",
-            connectsRoomB_Id = "Garage"
-        });
+        // Locate or Create Foyer to Garage Door & Set Properties
+        DoorSpec foyerToGarageDoor = plan.doors.Find(d => d.doorId == "FoyerToGarageDoor");
+        if (foyerToGarageDoor == null)
+        {
+            foyerToGarageDoor = new DoorSpec();
+            plan.doors.Add(foyerToGarageDoor);
+        }
+        foyerToGarageDoor.doorId = "FoyerToGarageDoor";
+        foyerToGarageDoor.type = DoorType.Hinged;
+        foyerToGarageDoor.width = (2f + 8f/12f) * FEET_TO_METERS; // 2'8"
+        foyerToGarageDoor.height = (6f + 8f/12f) * FEET_TO_METERS; // 6'8"
+        foyerToGarageDoor.position = new Vector3(foyerPos.x, foyerPos.y, foyerPos.z + foyerDepth / 2f); // Centered on Foyer's west wall
+        foyerToGarageDoor.wallId = "Wall_Foyer_W";
+        foyerToGarageDoor.connectsRoomA_Id = "Foyer";
+        foyerToGarageDoor.connectsRoomB_Id = "Garage";
 
-        // Create Foyer to Living Room Opening
-        plan.openings.Add(new OpeningSpec {
-            openingId = "FoyerToLivingRoomOpening",
-            type = OpeningType.CasedOpening,
-            width = 5f * FEET_TO_METERS, // 5ft wide opening
-            height = (6f + 8f/12f) * FEET_TO_METERS, // 6'8"
-            // Position on Foyer's east wall (foyerPos.x + foyerWidth), partway along its depth.
-            position = new Vector3(foyerPos.x + foyerWidth, foyerPos.y, foyerPos.z + foyerDepth / 2f),
-            wallId = "Wall_Foyer_E",
-            connectsRoomA_Id = "Foyer",
-            connectsRoomB_Id = "LivingRoom"
-        });
+        // Locate or Create Foyer to Living Room Opening & Set Properties
+        OpeningSpec foyerToLivingRoomOpening = plan.openings.Find(o => o.openingId == "FoyerToLivingRoomOpening");
+        if (foyerToLivingRoomOpening == null)
+        {
+            foyerToLivingRoomOpening = new OpeningSpec();
+            plan.openings.Add(foyerToLivingRoomOpening);
+        }
+        foyerToLivingRoomOpening.openingId = "FoyerToLivingRoomOpening";
+        foyerToLivingRoomOpening.type = OpeningType.CasedOpening;
+        foyerToLivingRoomOpening.width = 5f * FEET_TO_METERS; // 5ft wide opening
+        foyerToLivingRoomOpening.height = (6f + 8f/12f) * FEET_TO_METERS; // 6'8"
+        foyerToLivingRoomOpening.position = new Vector3(foyerPos.x + foyerWidth, foyerPos.y, foyerPos.z + foyerDepth / 2f); // Centered on Foyer's east wall
+        foyerToLivingRoomOpening.wallId = "Wall_Foyer_E";
+        foyerToLivingRoomOpening.connectsRoomA_Id = "Foyer";
+        foyerToLivingRoomOpening.connectsRoomB_Id = "LivingRoom";
         // --- End of Foyer Door/Opening modifications ---
     }
 

--- a/Echoes of the Hollow/Assets/Editor/TransformCaptureWindow.cs
+++ b/Echoes of the Hollow/Assets/Editor/TransformCaptureWindow.cs
@@ -720,7 +720,7 @@ public class TransformCaptureWindow : EditorWindow
     /// <returns>The detected HouseComponentType.</returns>
     private static HouseComponentType CalculateComponentType(GameObject obj)
     {
-        if (obj.name == "ProceduralHouse_Generated") return HouseComponentType.ProceduralHouseRoot;
+        if (obj.name.StartsWith("ProceduralHouse_Generated")) return HouseComponentType.ProceduralHouseRoot;
         if (obj.name.StartsWith("Foundation")) return HouseComponentType.Foundation;
         if (obj.name.StartsWith("Roof_")) return HouseComponentType.Roof;
         if (obj.name.StartsWith("Wall_")) return HouseComponentType.Wall;


### PR DESCRIPTION
This commit addresses two separate test failures:

1.  Corrects a regression in `TransformCaptureTests.DetectComponentType_ProceduralHouseRoot`. The `DetectComponentType` method in `TransformCaptureWindow.cs` was changed from an exact name match for "ProceduralHouse_Generated" to a `StartsWith` check. This makes the detection more robust for objects like "ProceduralHouse_Generated_TestObj".

2.  Fixes the `HousePlanTests.TestFoyerData` test. The `PopulateDataFromBlueprint` method in `BlueprintImporter.cs` was updated to ensure the Foyer data matches the test's specific expectations:
    - The "FrontDoor" `DoorSpec` is now correctly created/updated with a width of 0.9144f and a `swingDirection` of `SwingDirection.InwardSouth`.
    - Connections for the Foyer are verified:
        - "FrontDoor" connects "Foyer" to "CoveredEntry".
        - "FoyerToGarageDoor" connects "Foyer" to "Garage". - "FoyerToLivingRoomOpening" connects "Foyer" to "LivingRoom". This ensures the Foyer is connected to 2 doors and 1 opening as asserted by the test.