### PR TITLE
Fix: Correct wall pivot and coordinate space in capture and diff

### DIFF
--- a/Echoes of the Hollow/Assets/Editor/HousePlanDiffer.cs
+++ b/Echoes of the Hollow/Assets/Editor/HousePlanDiffer.cs
@@ -147,7 +147,25 @@ public static class HousePlanDiffer
         CompareRooms(existingPlan.rooms, capturedRooms, resultSet.roomDiffs);
 
         // Compare Walls
-        List<WallSegment> allExistingWalls = FlattenWallsFromPlan(existingPlan);
+// --- START: NEW World-Space Conversion Logic ---
+List<WallSegment> allExistingWalls = new List<WallSegment>();
+if (existingPlan != null && existingPlan.rooms != null)
+{
+    foreach (var room in existingPlan.rooms)
+    {
+        if (room.walls == null) continue;
+
+        foreach (var localWall in room.walls)
+        {
+            WallSegment worldWall = localWall; // Copy the struct
+            // Convert local start/end points to world space using the room's position
+            worldWall.startPoint = room.position + localWall.startPoint;
+            worldWall.endPoint = room.position + localWall.endPoint;
+            allExistingWalls.Add(worldWall);
+        }
+    }
+}
+// --- END: NEW World-Space Conversion Logic ---
         List<KeyValuePair<string, WallSegment>> targetWallEntries = GenerateWallEntries(allExistingWalls);
         List<KeyValuePair<string, WallSegment>> capturedWallEntries = GenerateWallEntries(sceneWalls);
         CompareWalls(targetWallEntries, capturedWallEntries, resultSet.wallDiffs);

--- a/Echoes of the Hollow/Assets/Editor/TransformCaptureWindow.cs
+++ b/Echoes of the Hollow/Assets/Editor/TransformCaptureWindow.cs
@@ -1638,10 +1638,8 @@ public class TransformCaptureWindow : EditorWindow
 
                     WallSegment wallSeg = new WallSegment();
 
-                    Vector3 center = go.transform.position;
-                    Vector3 halfLengthDir = go.transform.right * analyzedWall.wallLength / 2f;
-                    wallSeg.startPoint = center - halfLengthDir;
-                    wallSeg.endPoint = center + halfLengthDir;
+                                wallSeg.startPoint = go.transform.position;
+                                wallSeg.endPoint = go.transform.position + (go.transform.right * analyzedWall.wallLength);
 
                     wallSeg.thickness = analyzedWall.determinedThickness;
                     wallSeg.isExterior = analyzedWall.isLikelyExterior;


### PR DESCRIPTION
Bug 1: TransformCaptureWindow Wall Pivot
- I modified `TransformCaptureWindow.cs` in `CaptureSceneDataAsStructs`.
- I changed wall endpoint calculation to use the wall's start point as its pivot, instead of assuming a center pivot. This ensures accurate `startPoint` and `endPoint` capture for walls created with pivots at their start.

Bug 2: HousePlanDiffer Coordinate Space
- I modified `HousePlanDiffer.cs` in `ComparePlanToScene`.
- I implemented logic to convert wall coordinates from the `HousePlanSO` (room-local space) to world space before comparison with captured scene data.
- This resolves incorrect diff results for walls in rooms not at the world origin.