### PR TITLE
Refactor: Use authoritative wallId for wall naming

### DIFF
--- a/Echoes of the Hollow/Assets/HousePlan/RoomBuilder.cs
+++ b/Echoes of the Hollow/Assets/HousePlan/RoomBuilder.cs
@@ -25,7 +25,6 @@ public static class RoomBuilder
 
         GameObject root = new GameObject("Walls_Interior");
         HashSet<string> builtKeys = new HashSet<string>();
-        int wallIndex = 0;
 
         foreach (RoomData room in housePlan.rooms)
         {
@@ -51,10 +50,9 @@ public static class RoomBuilder
                 GameObject wall = BuildWallSegment(segment, room.position, storyHeight, housePlan.interiorWallThickness, housePlan);
                 if (wall != null)
                 {
-                    wall.name = $"Wall_{room.roomId}_{wallIndex}";
+                    wall.name = segment.wallId;
                     wall.transform.SetParent(root.transform, false);
                     // ProcessWallCutouts(segment, wall.name, housePlan); // Removed call
-                    wallIndex++;
                 }
             }
         }

--- a/Echoes of the Hollow/Assets/HousePlan/WallBuilder.cs
+++ b/Echoes of the Hollow/Assets/HousePlan/WallBuilder.cs
@@ -30,23 +30,20 @@ public static class WallBuilder
                 continue;
             }
 
-            int wallIndex = 0;
             foreach (WallSegment segment in room.walls)
             {
                 if (!segment.isExterior)
                 {
-                    wallIndex++;
                     continue;
                 }
 
                 GameObject wallObj = BuildWallSegment(segment, room.position, storyHeight, housePlan.exteriorWallThickness, housePlan); // Added housePlan argument
                 if (wallObj != null)
                 {
-                    wallObj.name = $"Wall_{room.roomId}_{wallIndex}";
+                    wallObj.name = segment.wallId;
                     wallObj.transform.SetParent(root.transform, false);
                     // ProcessWallCutouts(segment, wallObj.name, housePlan); // Removed call
                 }
-                wallIndex++;
             }
         }
 


### PR DESCRIPTION
I refactored `RoomBuilder.cs` and `WallBuilder.cs` to use the `wallId` property from `WallSegment` (defined in `HousePlanSO`) for naming wall GameObjects.

This change addresses an issue where wall names were being generated using a local counter, leading to incorrect names for interior and exterior walls. Using the authoritative `wallId` ensures correct and consistent naming.